### PR TITLE
Bump docs version and vendored singularityCE for 3.8

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -52,7 +52,7 @@ copyright = u'2017-2021, Sylabs Inc & Project Contributors'
 # built documents.
 #
 # The short X.Y version.
-version = '3.7'
+version = '3.8'
 # We have not had separate docs per release version for some time, so set
 # release = version here.
 release = version

--- a/quick_start.rst
+++ b/quick_start.rst
@@ -92,7 +92,7 @@ page). Alternatively, follow the commands here:
 
 .. code-block:: none
 
-    $ export VERSION=1.14.12 OS=linux ARCH=amd64 && \  # Replace the values as needed
+    $ export VERSION=1.16.4 OS=linux ARCH=amd64 && \  # Replace the values as needed
       wget https://dl.google.com/go/go$VERSION.$OS-$ARCH.tar.gz && \ # Downloads the required Go package
       sudo tar -C /usr/local -xzvf go$VERSION.$OS-$ARCH.tar.gz && \ # Extracts the archive
       rm go$VERSION.$OS-$ARCH.tar.gz    # Deletes the ``tar`` file


### PR DESCRIPTION
## Description of the Pull Request (PR):

Bump docs version and vendored singularityCE for 3.8

## This fixes or addresses the following GitHub issues:

- Fixes #9 
