### PR TITLE
Update environment_and_metadata.rst

### DIFF
--- a/environment_and_metadata.rst
+++ b/environment_and_metadata.rst
@@ -659,10 +659,10 @@ And the output would look like:
 
 
 ^^^^^^^^^^^^^^^^^^^^^^^
-``-h`` / ``--helpfile``
+``-H`` / ``--helpfile``
 ^^^^^^^^^^^^^^^^^^^^^^^
 
-The ``-h`` or ``-helpfile`` flag will show the container's description
+The ``-H`` or ``-helpfile`` flag will show the container's description
 in the ``%help`` section of its definition file.
 
 You can call it this way:


### PR DESCRIPTION
To display the %help section of the definition file, a capital H is needed '-H'

## Description of the Pull Request (PR):

Write your description of the PR here. Be sure to include as much background,
and details necessary for the reviewers to understand exactly what this is
fixing or enhancing.


## This fixes or addresses the following GitHub issues:

- Fixes #
