### PR TITLE
Refactor CI configuration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,12 +1,60 @@
 version: 2.1
 
+orbs:
+  go: circleci/go@1.7
+
+parameters:
+  go-version:
+    type: string
+    default: '1.17.1'
+
 executors:
   node:
     docker:
       - image: node:16
   python:
     docker:
-      - image: python:3.9-buster
+      - image: python:3.9-bullseye
+  ubuntu-machine:
+    machine:
+     image: ubuntu-2004:202107-02
+
+commands:
+  install-deps-apt:
+    parameters:
+      sudo:
+        type: boolean
+        default: true
+    steps:
+      - run:
+          name: Update package indexes
+          command: <<# parameters.sudo >>sudo <</ parameters.sudo >>apt-get -q update
+      - run:
+          name: Install singularity dependencies
+          command: <<# parameters.sudo >>sudo <</ parameters.sudo >>apt-get -q install -y build-essential squashfs-tools libseccomp-dev libssl-dev uuid-dev cryptsetup-bin libgpgme-dev
+  install-latex-apt:
+    parameters:
+        sudo:
+          type: boolean
+          default: true
+    steps:
+      - run:
+          name: Install LaTeX environment
+          command: <<# parameters.sudo >>sudo <</ parameters.sudo >>apt-get -q install -y texlive-latex-extra latexmk
+  install-deps-python:
+    parameters:
+      sudo:
+        type: boolean
+        default: true
+    steps:
+      - run:
+          name: Install python dependencies
+          command: <<# parameters.sudo >>sudo <</ parameters.sudo >>pip install sphinx sphinx-rtd-theme rstcheck pygments
+  init-submodules:
+    steps:
+      - run:
+          name: Initialize git submodules
+          command: git submodule update --init --recursive
 
 jobs:
   lint_markdown:
@@ -24,39 +72,22 @@ jobs:
     executor: python
     steps:
       - checkout
-      - run:
-          name: Install sphinx
-          command: |
-            pip install sphinx sphinx-rtd-theme rstcheck pygments
+      - install-deps-python:
+         sudo: false
       - run:
           name: Lint rst
           command: |
             rstcheck --ignore-language c,c++ --report warning *.rst
 
   make_html:
-    executor: python
+    executor: ubuntu-machine
     steps:
       - checkout
-      - run:
-          name: Singularity submodule init
-          command: |
-            git submodule update --init --recursive
-      - run:
-          name: Install sphinx
-          command: |
-            pip install sphinx sphinx-rtd-theme restructuredtext_lint pygments
-      - run:
-          name: Install singularity deps
-          command: |
-            apt-get update -y && \
-            apt-get install -f -y build-essential libssl-dev uuid-dev squashfs-tools libseccomp-dev cryptsetup-bin libgpgme-dev
-      - run:
-          name: Install Go 1.17
-          command: |
-            wget https://dl.google.com/go/go1.17.linux-amd64.tar.gz
-            rm -rf /usr/local/go
-            tar -C /usr/local -xzf go1.17.linux-amd64.tar.gz
-            ln -s /usr/local/go/bin/go /usr/local/bin/go
+      - install-deps-apt
+      - install-deps-python
+      - go/install:
+          version: << pipeline.parameters.go-version >>
+      - init-submodules  
       - run:
           name: make html
           command: |
@@ -66,33 +97,15 @@ jobs:
           destination: html
 
   make_pdf_epub:
-    executor: python
+    executor: ubuntu-machine
     steps:
       - checkout
-      - run:
-          name: Install sphinx
-          command: |
-            pip install sphinx sphinx-rtd-theme restructuredtext_lint pygments
-      - run:
-          name: submodule init
-          command: |
-            git submodule update --init --recursive
-      - run:
-          name: Install singularity deps
-          command: |
-            apt-get update -y && \
-            apt-get install -f -y build-essential libssl-dev uuid-dev squashfs-tools libseccomp-dev cryptsetup-bin libgpgme-dev
-      - run:
-          name: Install Go 1.17
-          command: |
-            wget https://dl.google.com/go/go1.17.linux-amd64.tar.gz
-            rm -rf /usr/local/go
-            tar -C /usr/local -xzf go1.17.linux-amd64.tar.gz
-            ln -s /usr/local/go/bin/go /usr/local/bin/go
-      - run:
-          name: Install TeXlive
-          command: |
-            apt-get install -f -y texlive-latex-extra latexmk
+      - install-deps-apt
+      - install-latex-apt
+      - install-deps-python
+      - go/install:
+          version: << pipeline.parameters.go-version >>
+      - init-submodules  
       - run:
           name: make pdf
           command: |


### PR DESCRIPTION
* Structure more like the SingularityCE codebase CI.

* Use orb to provide Go.

* Build the docs on Ubuntu 20.04 machine, for consistency with the
  codebase CI.... since we build SingularityCE here to generate the CLI docs.
