### PR TITLE
Add software licenses to appendix (3.9)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,7 +50,7 @@ commands:
     steps:
       - run:
           name: Install python dependencies
-          command: <<# parameters.sudo >>sudo <</ parameters.sudo >>pip install sphinx sphinx-rtd-theme rstcheck pygments
+          command: <<# parameters.sudo >>sudo <</ parameters.sudo >>pip install sphinx sphinx-rtd-theme rstcheck pygments m2r2
   init-submodules:
     steps:
       - run:

--- a/.rstcheck.cfg
+++ b/.rstcheck.cfg
@@ -1,0 +1,3 @@
+[rstcheck]
+ignore_directives=mdinclude
+

--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,5 @@
 Copyright (c) 2017, SingularityWare, LLC. All rights reserved.
-Copyright (c) 2018-2021, Sylabs, Inc. All rights reserved.
+Copyright (c) 2018-2022, Sylabs, Inc. All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/README.md
+++ b/README.md
@@ -23,10 +23,11 @@ Sphinx is written in Python. To get setup to contribute:
 
 - Install Python 3.5 or newer, from your OS package manager or the [Python download
   site](https://www.python.org/downloads/)
-- Use `pip3`to install Sphinx and the RTD theme package into your home directory:
+- Use `pip3`to install Sphinx, RTD theme package, and extensions / linters into
+  your home directory:
 
 ```sh
-pip3 install --user Sphinx sphinx-rtd-theme
+pip3 install --user sphinx sphinx-rtd-theme rstcheck pygments m2r2
 ```
 
 If your version of python 3 does not come with `pip` / `pip3`, you may need to

--- a/conf.py
+++ b/conf.py
@@ -45,7 +45,7 @@ master_doc = 'index'
 # General information about the project.
 project = u'SingularityCE User Guide'
 author = u'SingularityCE Project Contributors'
-copyright = u'2017-2021, Sylabs Inc & Project Contributors'
+copyright = u'2017-2022, Sylabs Inc & Project Contributors'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the

--- a/conf.py
+++ b/conf.py
@@ -28,13 +28,13 @@ import os
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = []
+extensions = ['m2r2']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
 
 # The suffix of source filenames.
-source_suffix = '.rst'
+source_suffix = ['.rst']
 
 # The encoding of source files.
 #source_encoding = 'utf-8-sig'
@@ -69,7 +69,7 @@ release = version
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
-exclude_patterns = ['_build']
+exclude_patterns = ['_build', 'singularity_source', '.github', 'README.md']
 
 # The reST default role (used for this markup: `text`) to use for all
 # documents.

--- a/index.rst
+++ b/index.rst
@@ -135,4 +135,4 @@ other users, or simply testing new releases.
    :maxdepth: 1
 
    Command Line Reference <cli>
-   License <license>
+   Licenses <license>

--- a/license.rst
+++ b/license.rst
@@ -1,8 +1,22 @@
-#########
- License
-#########
+##########
+ Licenses
+##########
+
+***************
+ Documentation
+***************
 
 This documentation is subject to the following 3-clause BSD license:
 
 .. include:: LICENSE
    :literal:
+
+************************
+ {Singularity} Software
+************************
+
+.. mdinclude:: singularity_source/LICENSE.md
+
+.. mdinclude:: singularity_source/LICENSE_THIRD_PARTY.md
+
+.. mdinclude:: singularity_source/LICENSE_DEPENDENCIES.md

--- a/replacements.py
+++ b/replacements.py
@@ -12,7 +12,7 @@ def variableReplace(app, docname, source):
 # Add the needed variables to be replaced either on code or on text on the next
 # dictionary structure.
 variable_replacements = {
-    "{InstallationVersion}": "3.9.2",
+    "{InstallationVersion}": "3.9.5",
     "{version}": "3.9",
     "{adminversion}": "3.9",
     # The 'Singularity' noun is now a replacement so we can have


### PR DESCRIPTION
Bump singularity_source and add the SingularityCE project software licenses to the appendix, so that they are distributed with the documentation and easy to find / review.