### PR TITLE
Fix incorrect TMDIR variable name

### DIFF
--- a/troubleshooting.rst
+++ b/troubleshooting.rst
@@ -29,7 +29,7 @@ this is the issue, then the sandbox should work.
     sudo singularity build --sandbox [fatty] Singularity
 
 **Solution**
-You simply need to set the ``$SINGULARITY_CACHEDIR`` to a different location that you have more
+You simply need to set the ``$TMPDIR`` to a different location that you have more
 room.
 
 -------------------------------------


### PR DESCRIPTION
## Description of the Pull Request (PR):

Just ran into the issue with `no space left on device`. 
It turns out it is the `$TMPDIR` variable rather than the `$SINGULARITY_CACHEDIR` variable that needs to be modified. 

## This fixes or addresses the following GitHub issues:

- Fixes #
