### PR TITLE
Document --no-eval added in 3.10

### DIFF
--- a/environment_and_metadata.rst
+++ b/environment_and_metadata.rst
@@ -245,8 +245,6 @@ workflow.
 ``--env`` option
 ================
 
-*New in {Singularity} 3.6*
-
 The ``--env`` option on the ``run/exec/shell`` commands allows you to
 specify environment variables as ``NAME=VALUE`` pairs:
 
@@ -264,8 +262,6 @@ variables include special characters.
 
 ``--env-file`` option
 =====================
-
-*New in {Singularity} 3.6*
 
 The ``--env-file`` option lets you provide a file that contains
 environment variables as ``NAME=VALUE`` pairs, e.g.:
@@ -910,15 +906,14 @@ SIF file metadata descriptor.
    dynamically written at runtime, *and should not be modified* in the
    container.
 
--  **env**: All ``*.sh`` files in this directory are sourced in
-   alphanumeric order when the container is started. For legacy purposes
-   there is a symbolic link called ``/environment`` that points to
-   ``/.singularity.d/env/90-environment.sh``. Whenever possible, avoid
-   modifying or creating environment files manually to prevent potential
-   issues building & running containers with future versions of
-   {Singularity}. Beginning with {Singularity} 3.6, additional
-   facilities such as ``--env`` and ``--env-file`` are available to
-   allow manipulation of the container environment at runtime.
+-  **env**: All ``*.sh`` files in this directory are sourced in alphanumeric
+   order when the container is started. For legacy purposes there is a symbolic
+   link called ``/environment`` that points to
+   ``/.singularity.d/env/90-environment.sh``. Whenever possible, avoid modifying
+   or creating environment files manually to prevent potential issues building &
+   running containers with future versions of {Singularity}. Additional
+   facilities such as ``--env`` and ``--env-file`` are available to allow
+   manipulation of the container environment at runtime.
 
 -  **labels.json**: The json file that stores a containers labels
    described above.

--- a/environment_and_metadata.rst
+++ b/environment_and_metadata.rst
@@ -129,7 +129,7 @@ The ``%runscript`` is set to echo the value.
    initialization tasks because this would impact users running the
    image and the execution could abort due to timeout.
 
-Build Time Cariables in ``%post``
+Build Time Variables in ``%post``
 =================================
 
 In some circumstances the value that needs to be assigned to an

--- a/environment_and_metadata.rst
+++ b/environment_and_metadata.rst
@@ -22,35 +22,6 @@ details such as the version of {Singularity} used are present as
 :ref:`labels <sec:labels>` on a container. You can also specify your own
 to be recorded against your container.
 
-******************************
- Changes in {Singularity} 3.6
-******************************
-
-{Singularity} 3.6 modified the ways in which environment variables are
-handled to allow long-term stability and consistency that has been
-lacking in prior versions. It also introduced new ways of setting
-environment variables, such as the ``--env`` and ``--env-file`` options.
-
-.. warning::
-
-   If you have containers built with {Singularity} <3.6, and frequently
-   set and override environment variables, please review this section
-   carefully. Some behavior has changed.
-
-Summary of changes
-==================
-
-   -  When building a container, the environment defined in the base
-      image (e.g. a Docker image) is available during the ``%post``
-      section of the build.
-
-   -  An environment variable set in a container image, from the
-      bootstrap base image, or in the ``%environment`` section of a
-      definition file *will not* be overridden by a host environment
-      variable of the same name. The ``--env``, ``--env-file``, or
-      ``SINGULARITYENV_`` methods must be used to explicitly override a
-      environment variable set by the container image.
-
 **********************
  Environment Overview
 **********************
@@ -91,7 +62,7 @@ container, rather than when running a container, see :ref:`build
 environment section <build-environment>`.
 
 *******************************
- Environment from a base image
+ Environment From a Base Image
 *******************************
 
 When you build a container with {Singularity} you might *bootstrap* from
@@ -121,7 +92,7 @@ You can override the inherited environment with ``SINGULARITYENV_`` vars, or the
 not be overridden by host environment variables of the same name.
 
 ************************************
- Environment from a definition file
+ Environment From a Definition File
 ************************************
 
 Environment variables can be included in your container by adding them
@@ -158,7 +129,7 @@ The ``%runscript`` is set to echo the value.
    initialization tasks because this would impact users running the
    image and the execution could abort due to timeout.
 
-Build time variables in ``%post``
+Build Time Cariables in ``%post``
 =================================
 
 In some circumstances the value that needs to be assigned to an
@@ -174,7 +145,7 @@ Variables set in the ``%post`` section through
 ``%environment``.
 
 ***************************
- Environment from the host
+ Environment From the Host
 ***************************
 
 If you have environment variables set outside of your container, on the
@@ -239,7 +210,7 @@ environment variables for correct operation of most software.
    consider using ``--cleanenv``.
 
 ********************************************
- Environment from the {Singularity} runtime
+ Environment From the {Singularity} Runtime
 ********************************************
 
 It can be useful for a program to know when it is running in a
@@ -264,7 +235,7 @@ program running in the container.
       container.
 
 **********************************
- Overriding environment variables
+ Overriding Environment Variables
 **********************************
 
 You can override variables that have been set in the container image, or
@@ -382,24 +353,53 @@ to the start) of the ``PATH`` variable in the container.
 Alternatively you could use the ``--env`` option to set a
 ``PREPEND_PATH`` variable, e.g. ``--env PREPEND_PATH=/startpath``.
 
-Escaping and evaluation of environment variables
-================================================
+************************************************
+Escaping and Evaluation of Environment Variables
+************************************************
 
-{Singularity} uses an embedded shell interpreter to process the
-container startup scripts and environment. When this processing is
-performed, a single step of shell evaluation happens in the container
-context. The shell from which you are running {Singularity} may also
-evaluate variables on your command line before passing them to
-{Singularity}.
+{Singularity} uses an embedded shell interpreter to process the container
+startup scripts and environment. When this processing is performed, by default a
+single step of shell evaluation happens in the container context. The shell from
+which you are running {Singularity} may also evaluate variables on your command
+line before passing them to {Singularity}.
 
-.. warning::
+Docker / OCI Compatibility
+==========================
 
-   This behavior differs from Docker/OCI handling of environment
-   variables / ``ENV`` directives. You may need additional quoting and
-   escaping to replicate behavior. See below.
+This default behavior of {Singularity} differs from Docker/OCI handling of
+environment variables / ``ENV`` directives. To avoid the extra evaluation of
+variables that {Singularity} performs you can:
 
-Using host variables
---------------------
+* Follow the instructions about escaping in the sections below, to add
+  additional escape characters and/or quoting.
+* Use the ``--no-eval`` or ``--compat`` flags.
+
+
+``--no-eval`` prevents {Singularity} from evaluating environment variables on
+container startup, so that they will take the same value as with a Docker/OCI
+runtime:
+
+.. code::
+
+   # Set an environment variable that would run `date` if evaluated
+   $ export SINGULARITYENV_MYVAR='$(date)'
+
+   # Default behavior
+   # MYVAR was evaluated in the container, and is set to the output of `date`
+   $ singularity run ~/ubuntu_latest.sif env | grep MYVAR
+   MYVAR=Tue Apr 26 14:37:07 CDT 2022
+
+   # --no-eval / --compat behavior
+   # MYVAR was not evaluated and is a literal `$(date)`
+   $ singularity run --no-eval ~/ubuntu_latest.sif env | grep MYVAR
+   MYVAR=$(date)
+
+
+The ``--compat`` flag is a short-hand flag to activate ``--no-eval`` along with
+other Docker/OCI compatibility flags. See :ref:`compat-flag` for more details.
+
+Using Host Variables
+====================
 
 To set a container environment variable to the value of a variable on
 the host, use double quotes around the variable, so that it is
@@ -421,7 +421,7 @@ substituted before the host shell runs ``singularity``.
    correctly.
 
 Using Container Variables
--------------------------
+=========================
 
 To set an environment variable to a value that references another
 variable inside the container, you should escape the ``$`` sign to
@@ -442,7 +442,7 @@ APPEND_PATH="/endpath"``, which uses the special ``APPEND/PREPEND``
 handling for ``PATH`` discussed above.
 
 Quoting / Avoiding Evaluation
------------------------------
+=============================
 
 If you need to pass an environment variable into the container
 verbatim, it must be quoted and escaped appropriately. For example, if
@@ -467,9 +467,9 @@ level of escaping:
 
    singularity run --env='LD_PRELOAD=/foo/bar/\$LIB/baz.so' mycontainer.sif
 
-
+*******************************
 Environment Variable Precedence
-===============================
+*******************************
 
 When a container is run with {Singularity}, the container
 environment is constructed in the following order:

--- a/environment_and_metadata.rst
+++ b/environment_and_metadata.rst
@@ -353,6 +353,8 @@ to the start) of the ``PATH`` variable in the container.
 Alternatively you could use the ``--env`` option to set a
 ``PREPEND_PATH`` variable, e.g. ``--env PREPEND_PATH=/startpath``.
 
+.. _escaping-environment:
+
 ************************************************
 Escaping and Evaluation of Environment Variables
 ************************************************

--- a/singularity_and_docker.rst
+++ b/singularity_and_docker.rst
@@ -855,6 +855,8 @@ around this, use the ``--no-init`` flag to disable the shim:
    ...
    # NO WARNINGS
 
+.. _compat-flag:
+
 *******************************
  Docker-like ``--compat`` Flag
 *******************************

--- a/singularity_and_docker.rst
+++ b/singularity_and_docker.rst
@@ -789,6 +789,39 @@ For example, the ``docker://openjdk:latest`` container sets ``JAVA_HOME``:
    $ singularity run docker://openjdk:latest echo \$JAVA_HOME
    /test
 
+
+Environment Variable Escaping / Evaluation
+==========================================
+
+The default behavior of {Singularity} differs from Docker/OCI handling of
+environment variables as {Singularity} uses a shell interpreter to process
+environment on container startup, in a manner that evaluates environment
+variables. To avoid the extra evaluation of variables that {Singularity}
+performs you can:
+
+* Follow the instructions in the :ref:`escaping-environment` section to
+  explictly escape environment variables.
+* Use the ``--no-eval`` flag.
+
+``--no-eval`` prevents {Singularity} from evaluating environment variables on
+container startup, so that they will take the same value as with a Docker/OCI
+runtime:
+
+.. code::
+
+   # Set an environment variable that would run `date` if evaluated
+   $ export SINGULARITYENV_MYVAR='$(date)'
+
+   # Default behavior
+   # MYVAR was evaluated in the container, and is set to the output of `date`
+   $ singularity run ~/ubuntu_latest.sif env | grep MYVAR
+   MYVAR=Tue Apr 26 14:37:07 CDT 2022
+
+   # --no-eval / --compat behavior
+   # MYVAR was not evaluated and is a literal `$(date)`
+   $ singularity run --no-eval ~/ubuntu_latest.sif env | grep MYVAR
+   MYVAR=$(date)
+
 Namespace & Device Isolation
 ============================
 
@@ -869,6 +902,7 @@ to using all of:
 -  ``--no-init``
 -  ``--no-umask``
 -  ``--writable-tmpfs``
+-  ``--no-eval``
 
 A container run with ``--compat`` has:
 
@@ -880,10 +914,12 @@ A container run with ``--compat`` has:
    which will be discarded at container exit.
 -  A minimal ``/dev`` tree, that does not expose host devices inside the
    container (except GPUs when used with ``--nv`` or ``--rocm``).
--  An clean environment, not including environment variables set on the
+-  A clean environment, not including environment variables set on the
    host.
 -  Its own PID and IPC namespaces.
 -  No shim init process.
+-  Argument and environment variable handling matching Docker / OCI runtimes,
+   with respect to evaluation and escaping.
 
 These options will allow most, but not all, Docker / OCI containers to
 execute correctly under {Singularity}. The user namespace and network
@@ -960,11 +996,40 @@ inside a container.
 Argument Handling
 =================
 
-Because {Singularity} runscripts are evaluated shell scripts
-arguments can behave slightly differently than in Docker/OCI
-runtimes, if they contain shell code that may be evaluated. To
-replicate Docker/OCI behavior you may need additional escaping or
-quoting of arguments.
+Because {Singularity} runscripts are evaluated shell scripts, arguments can
+behave slightly differently than in Docker/OCI runtimes if they contain shell
+code that may be evaluated. 
+
+If you are using a container that was directly built or run from a Docker/OCI
+source, with {Singularity} 3.10 or later, the ``--no-eval`` flag will prevent
+this extra evaluation so that arguments are handled in a compatible manner:
+
+.. code:: 
+
+   # docker/OCI behavior
+   $ docker run -it --rm alpine echo "\$HOSTNAME"
+   $HOSTNAME
+
+   # Singularity default
+   $ singularity run docker://alpine echo "\$HOSTNAME"
+   p700
+
+   # Singularity with --no-eval
+   $ singularity run --no-eval docker://alpine echo "\$HOSTNAME"
+   $HOSTNAME
+
+.. note:: 
+
+   ``--no-eval`` will not change argument behavior for containers built with
+   {Singularity} 3.9 or earlier, as the handling is implemented in the runscript
+   that is built into the container.
+
+   You can check the version of {Singularity} used to build  a container with
+   ``singularity inspect mycontainer.sif``.
+
+To avoid evaluation without ``--no-eval``, and when using containers built with
+{Singularity} 3.9 or earlier, you will need to add an extra level of shell
+escaping to arguments on the command line:
 
 .. code::
 
@@ -978,7 +1043,7 @@ quoting of arguments.
    $HOSTNAME
 
 If you are running a binary inside a ``docker://`` container directly,
-using the ``exec`` command the argument handling mirrors Docker/OCI
+using the ``exec`` command, the argument handling mirrors Docker/OCI
 runtimes as there is no evaluated runscript.
 
 .. _sec:best_practices:
@@ -993,7 +1058,7 @@ however, there are some best practices that should be applied when
 creating Docker / OCI containers that will also be run using
 {Singularity}.
 
-   #. **Don't require execution by a specific user**
+   1. **Don't require execution by a specific user**
 
    Avoid using the ``USER`` instruction in your Docker file, as it is
    ignored by Singularity. Install and configure software inside the


### PR DESCRIPTION
## Description of the Pull Request (PR):

Drop 'Changes in 3.6'... we are now 4 minor versions and 2 years ahead of this.
Add `--no-eval` notes to environment section
Tidy header nesting, capitalization.

Add `--no-eval` notes to Docker compat section

## This fixes or addresses the following GitHub issues:

- Fixes #84 
