### PR TITLE
additional dependencies required for yum based distros

### DIFF
--- a/quick_start.rst
+++ b/quick_start.rst
@@ -61,7 +61,10 @@ On CentOS/RHEL:
    sudo yum install -y \
       libseccomp-devel \
       squashfs-tools \
-      cryptsetup
+      cryptsetup \
+      glib2-devel \
+      glibc-devel \
+      runc
 
 There are 3 broad steps to installing {Singularity}:
 


### PR DESCRIPTION


## Description of the Pull Request (PR):

I got the error

```
glib-2.0 headers are required to build conmon.
```

following the original instructions. I had to install the additional dependencies to get around the issue.

