### PR TITLE
fix oras bootstrap agent example

### DIFF
--- a/appendix.rst
+++ b/appendix.rst
@@ -611,7 +611,7 @@ module to use.
 
 .. code:: singularity
 
-   From: oras://registry/namespace/image:tag
+   From: registry/namespace/image:tag
 
 The ``From`` keyword is mandatory. It specifies the container to use as
 a base. Also,``tag`` is mandatory that refers to the version of image


### PR DESCRIPTION
## Description of the Pull Request (PR):

removed `oras://` from the `From:` line in the oras bootstrap agent example

## This fixes or addresses the following GitHub issues:

- Fixes #125 
