### PR TITLE
Update docker bootstraps / DOCKER_ vars handling

### DIFF
--- a/appendix.rst
+++ b/appendix.rst
@@ -113,14 +113,20 @@ below with their respective functionality.
 #. **SINGULARITY_DNS**: A list of the DNS server addresses separated by
    commas to be added in ``resolv.conf``.
 
+#. **SINGULARITY_DOCKER_HOST**: Host address / socket to use when pulling images
+   from a ``docker-daemon`` source. ``DOCKER_HOST`` without the
+   ``SINGULARITY_`` prefix is also accepted.
+
 #. **SINGULARITY_DOCKER_LOGIN**: To specify the interactive prompt for
    docker authentication.
 
-#. **SINGULARITY_DOCKER_USERNAME**: To specify a username for docker
-   authentication.
-
 #. **SINGULARITY_DOCKER_PASSWORD**: To specify the password for docker
-   authentication.
+   authentication. ``DOCKER_PASSWORD`` without the ``SINGULARITY_`` prefix is
+   also accepted.
+
+#. **SINGULARITY_DOCKER_USERNAME**: To specify the username for docker
+   authentication. ``DOCKER_USERNAME`` without the ``SINGULARITY_`` prefix is
+   also accepted.
 
 #. **SINGULARITY_DOWNLOAD_CONCURRENCY**: To specify how many concurrent streams
    when downloading (pulling) an image from cloud library.
@@ -950,21 +956,16 @@ only the bare essentials such that the ``%post`` section has what it
 needs to properly complete the build. One common package you may want to
 install when using the zypper build module is ``zypper`` itself.
 
-.. _docker-daemon-archive:
+.. _docker-daemon:
 
-``docker-daemon`` and ``docker-archive`` bootstrap agents
-=========================================================
-
-If you are using docker locally there are two options for creating
-{Singularity} images without the need for a repository. You can either
-build a SIF from a ``docker-save`` tar file or you can convert any
-docker image present in docker's daemon internal storage.
+``docker-daemon`` bootstrap agent
+=================================
 
 Overview
 --------
 
-``docker-daemon`` allows you to build a SIF from any docker image
-currently residing in docker's daemon internal storage:
+``docker-daemon`` allows you to build a SIF from any Docker image
+currently residing in the Docker daemon's internal storage:
 
 .. code:: console
 
@@ -984,8 +985,40 @@ currently residing in docker's daemon internal storage:
    INFO:    Creating SIF file...
    Singularity>
 
-while ``docker-archive`` permits you to do the same thing starting from
-a docker image stored in a ``docker-save`` formatted tar file:
+The ``SINGULARITY_DOCKER_HOST`` or ``DOCKER_HOST`` environment variables may be
+set to instruct {{Singularity}} to pull images from a Docker daemon that is not
+running at the default location. For example, when using a virtualized Docker you may be instructed to set ``DOCKER_HOST`` e.g.
+
+.. code:: 
+
+   To connect the Docker client to the Docker daemon, please set
+   export DOCKER_HOST=tcp://192.168.59.103:2375
+
+Keywords
+--------
+
+In a definition file, the ``docker-daemon`` bootstrap agent requires the source container reference to
+be provided with the ``From:`` keyword:
+
+.. code:: singularity
+
+   Bootstrap: docker-daemon
+   From: <image>:<tag>
+
+where both ``<image>`` and ``<tag>`` are mandatory fields that must be
+written explicitly.
+
+
+.. _docker-daemon:
+
+``docker-archive`` bootstrap agent
+==================================
+
+Overview
+--------
+
+The ``docker-archive`` boostrap agent allows you to create a {Singularity} image
+from a docker image stored in a ``docker save`` formatted tar file:
 
 .. code:: console
 
@@ -1006,24 +1039,13 @@ a docker image stored in a ``docker-save`` formatted tar file:
 Keywords
 --------
 
-The ``docker-daemon`` bootstrap agent can be used in a {Singularity}
-definition file as follows:
+In a definition file, the ``docker-archive`` bootstrap agent requires the path
+to the tar file containing the image to be specified with the ``From:`` keyword.
 
 .. code:: singularity
 
-   From: docker-daemon:<image>:<tag>
-
-where both ``<image>`` and ``<tag>`` are mandatory fields that must be
-written explicitly. The ``docker-archive`` bootstrap agent requires
-instead the path to the tar file containing the image:
-
-.. code:: singularity
-
-   From: docker-archive:<path-to-tar-file>
-
-Note that differently from the ``docker://`` bootstrap agent both
-``docker-daemon`` and ``docker-archive`` don't require a double slash
-``//`` after the colon in the agent name.
+   Bootstrap: docker-archive
+   From: <path-to-tar-file>
 
 .. _scratch-agent:
 
@@ -1073,6 +1095,7 @@ The resulting container provides a shell, and is 696KiB in size:
    Hello from a 696KiB container
 
 Keywords
+--------
 
 .. code:: singularity
 

--- a/definition_files.rst
+++ b/definition_files.rst
@@ -108,9 +108,9 @@ Other bootstrap agents
    Specification)
 -  :ref:`oci-archive <cli-oci-archive-bootstrap-agent>` (tar files
    obeying the OCI Image Layout Specification)
--  :ref:`docker-daemon <docker-daemon-archive>` (images managed by the
+-  :ref:`docker-daemon <docker-daemon>` (images managed by the
    locally running docker daemon)
--  :ref:`docker-archive <docker-daemon-archive>` (archived docker
+-  :ref:`docker-archive <docker-archive>` (saved docker
    images)
 -  :ref:`arch <build-arch>` (Arch Linux)
 -  :ref:`busybox <build-busybox>` (BusyBox)

--- a/singularity_and_docker.rst
+++ b/singularity_and_docker.rst
@@ -189,6 +189,11 @@ Singularity accepts a username, and password / token, as
 respectively. These environment variables will override any stored
 credentials.
 
+If ``DOCKER_USERNAME`` and ``DOCKER_PASSWORD``, without the ``SINGULARITY_``
+prefix, are set they will also be used provided the ``SINGULARITY_`` equivalent
+is not overriding them. This allows a single set of environment variables to be
+set for both ``singularity`` and ``docker`` operations.
+
 .. code::
 
    $ export SINGULARITY_DOCKER_USERNAME=myuser


### PR DESCRIPTION
## Description of the Pull Request (PR):

* DOCKER_HOST is supported for docker-daemon bootstrap
* DOCKER_ env vars are used, as well as SINGULARITY_DOCKER_.
* Edits for docker-daemon / docker-archive correctness

## This fixes or addresses the following GitHub issues:

Fixes #136
Fixes #135
