### PR TITLE
updated heading style

### DIFF
--- a/appendix.rst
+++ b/appendix.rst
@@ -1,17 +1,17 @@
 .. _appendix:
 
-##########
- Appendix
-##########
+########
+Appendix
+########
 
 ..
    TODO oci & oci-archive along with http & https
 
 .. _singularity-environment-variables:
 
-***************************************
- {Singularity}'s environment variables
-***************************************
+*************************************
+{Singularity}'s environment variables
+*************************************
 
 {Singularity} 3.0 comes with some environment variables you can set or
 modify depending on your needs. You can see them listed alphabetically
@@ -400,9 +400,9 @@ below with their respective functionality.
 
 .. _buildmodules:
 
-***************
- Build Modules
-***************
+*************
+Build Modules
+*************
 
 .. _build-library-module:
 
@@ -989,7 +989,7 @@ The ``SINGULARITY_DOCKER_HOST`` or ``DOCKER_HOST`` environment variables may be
 set to instruct {{Singularity}} to pull images from a Docker daemon that is not
 running at the default location. For example, when using a virtualized Docker you may be instructed to set ``DOCKER_HOST`` e.g.
 
-.. code:: 
+.. code::
 
    To connect the Docker client to the Docker daemon, please set
    export DOCKER_HOST=tcp://192.168.59.103:2375

--- a/bind_paths_and_mounts.rst
+++ b/bind_paths_and_mounts.rst
@@ -1,8 +1,8 @@
 .. _bind-paths-and-mounts:
 
-#######################
- Bind Paths and Mounts
-#######################
+#####################
+Bind Paths and Mounts
+#####################
 
 .. _sec:bindpaths:
 
@@ -12,9 +12,9 @@ Unless `disabled by the system administrator
 directories within your container using bind mounts. This allows you to
 read and write data on the host system with ease.
 
-**********
- Overview
-**********
+********
+Overview
+********
 
 When {Singularity} ‘swaps’ the host operating system for the one inside
 your container, the host file systems becomes inaccessible. However, you
@@ -23,9 +23,9 @@ container. To enable this functionality, {Singularity} will bind
 directories back into the container via two primary methods:
 system-defined bind paths and user-defined bind paths.
 
-***************************
- System-defined bind paths
-***************************
+*************************
+System-defined bind paths
+*************************
 
 The system administrator has the ability to define what bind paths will
 be included automatically inside each container. Some bind paths are
@@ -82,9 +82,9 @@ To disable all ``bind path`` entries set in ``singularity.conf``, use
 
 .. _user-defined-bind-paths:
 
-*************************
- User-defined bind paths
-*************************
+***********************
+User-defined bind paths
+***********************
 
 Unless the system administrator has `disabled user control of binds
 <https://singularity-admindoc.readthedocs.io/en/latest/the_singularity_config_file.html#user-bind-control-boolean-default-yes>`_,
@@ -266,9 +266,9 @@ host ``$HOME`` directory with the ``--no-home`` flag.
 
    $ singularity shell --containall my_container.sif
 
-*************
- FUSE mounts
-*************
+***********
+FUSE mounts
+***********
 
 Filesystem in Userspace (FUSE) is an interface to allow filesystems to
 be mounted using code that runs in userspace, rather than in the Linux
@@ -373,9 +373,9 @@ added to your container, you can use the ``container`` mount type:
    Singularity> cat /server/etc/hostname
    server
 
-**************
- Image Mounts
-**************
+************
+Image Mounts
+************
 
 In {Singularity} 3.6 and above you can mount a directory contained in an
 image file into a container. This may be useful if you want to

--- a/build_env.rst
+++ b/build_env.rst
@@ -1,14 +1,14 @@
 .. _build-environment:
 
-###################
- Build Environment
-###################
+#################
+Build Environment
+#################
 
 .. _sec:buildenv:
 
-**********
- Overview
-**********
+********
+Overview
+********
 
 You may wish to customize your build environment by doing things such as
 specifying a custom cache directory for images or sending your Docker
@@ -17,9 +17,9 @@ other topics related to the build environment.
 
 .. _sec:cache:
 
-***************
- Cache Folders
-***************
+*************
+Cache Folders
+*************
 
 {Singularity} will cache SIF container images generated from remote
 sources, and any OCI/docker layers used to create them. The cache is
@@ -102,9 +102,9 @@ file:
 
    rm ~/.local/share/containers/cache/blob-info-cache-v1.boltdb
 
-****************
- Cache commands
-****************
+**************
+Cache commands
+**************
 
 The ``cache`` command for {Singularity} allows you to view and clean up
 your cache, without manually inspecting the cache directories.
@@ -212,9 +212,9 @@ use the ``type`` / ``-T`` option:
 
 .. _sec:temporaryfolders:
 
-*******************
- Temporary Folders
-*******************
+*****************
+Temporary Folders
+*****************
 
 When building a container, or pulling/running a {Singularity} container
 from a Docker/OCI source, a temporary working space is required. The
@@ -250,9 +250,9 @@ Remember to use ``-E`` option to pass the value of
    Set ``SINGULARITY_TMPDIR`` to a disk location, or disable the
    ``tmpfs`` ``/tmp`` mount on your system if you experience problems.
 
-**********************
- Encrypted Containers
-**********************
+********************
+Encrypted Containers
+********************
 
 Beginning in {Singularity} 3.4.0 it is possible to build and run
 encrypted containers. The containers are decrypted at runtime entirely
@@ -260,9 +260,9 @@ in kernel space, meaning that no intermediate decrypted data is ever
 present on disk or in memory. See :ref:`encrypted containers
 <encryption>` for more details.
 
-***********************
- Environment Variables
-***********************
+*********************
+Environment Variables
+*********************
 
 #. If a flag is represented by both a CLI option and an environment
    variable, and both are set, the CLI option will always take

--- a/cgroups.rst
+++ b/cgroups.rst
@@ -1,8 +1,8 @@
 .. _cgroups:
 
-##############################
- Limiting Container Resources
-##############################
+############################
+Limiting Container Resources
+############################
 
 It's often useful to limit the resources that are consumed by a container, e.g.
 to allow the container to only use 1 CPU, or 50% of the RAM on the system.
@@ -23,16 +23,16 @@ There are three ways to apply limits to a container that is run with
 {Singularity}:
 
 * Using the command line flags introduced in v3.10.
- 
+
 * Using the ``--apply-cgroups`` flag to apply a ``cgroups.toml`` file that
   defines the resource limits.
 
 * Using external tools such as ``systemd-run`` tool to apply limits, and then
   call ``singularity``.
 
-******************************
- Requirements - Linux Cgroups
-******************************
+****************************
+Requirements - Linux Cgroups
+****************************
 
 Resource limits are applied to containers using functionality in the Linux
 kernel known as *control groups* or *cgroups*. There are two versions of
@@ -63,9 +63,9 @@ about this.
 
 .. _cgroup_flags:
 
-***************************
- Command Line Limit Flags
-***************************
+*************************
+Command Line Limit Flags
+*************************
 
 {Singularity} 3.10 introduced a number of simple command line flags that you can
 use with `shell/run/exec` and the `instance` commands to directly apply resource
@@ -88,7 +88,7 @@ use.  The minimum is ``0.01`` or one tenth of a physical CPU. The maximum is the
 number of CPU cores on your system.
 
 .. code::
-   
+
    # Limit container to 3.5 CPUs
    $ singularity run --cpus 3.5 myfirstapp.sif
 
@@ -100,7 +100,7 @@ there is contention for CPUs*, i.e. the containers are able to consume more CPU
 time than is available.
 
 .. code::
-   
+
    # Container A - twice as much CPU priority as container B
    $ singularity run --cpu-shares 1024 myfirstapp.sif
 
@@ -115,7 +115,7 @@ run. For example, on a dual CPU system you might pin one container to the first
 should generally be set to the same value as ``--cpu-set-cpus``.
 
 .. code::
-   
+
    # Container A - first CPU
    $ singularity run --cpu-set-cpus 0-11 --cpu-set-mems 0-11 myfirstapp.sif
 
@@ -130,7 +130,7 @@ You can use suffixes such as ``M`` or ``G`` to specify megabytes or gigabytes.
 If the container tries to use more memory than its limit, the system will kill
 it.
 
-.. code:: 
+.. code::
 
    # Run a program that will use 10GB of RAM, with a 100MB limit
    $ singularity exec --memory 100M memhog.sif memhog 10G
@@ -140,7 +140,7 @@ it.
 limit set with ``--memory``. When there is contention for memory, the system
 will attempt to make sure the container doesn't exceed the soft limit.
 
-.. code:: 
+.. code::
 
    # Kill my program if it exceeds 10G, but aim for 8G if there is contention
    $ singularity exec --memory 10G --memory-reservation 8G myfirstapp.sif
@@ -169,7 +169,7 @@ value of ``-1`` means *unlimited swap*. If ``--memory-swap`` is not set or is
 IO Limits
 =========
 
-.. note:: 
+.. note::
 
    Requires the ``cfq`` or ``bfq`` IO scheduler to be configured for block IO on
    the system. This is common on modern distributions, but not universal. Ask
@@ -182,7 +182,7 @@ is contention for I/O with other containers. It may be useful to give high
 priority to a container that needs infrequent but time sensitive data access,
 running alongside an application that is continuously performing bulk reads.
 
-.. code:: 
+.. code::
 
    # Container A - ten times as much block IO priority as container B
    $ singularity run --blkio-weight 1000 myfirstapp.sif
@@ -193,7 +193,7 @@ running alongside an application that is continuously performing bulk reads.
 ``--blkio-weight-device`` sets a relative weight for the container when performing
 block I/O on a specific device. Specify the device and weight as ``<device path>:weight``:
 
-.. code:: 
+.. code::
 
    # Container A - ten times as much block IO priority as container B on disk /dev/sda
    $ singularity run --blkio-weight-device /dev/sda:1000 myfirstapp.sif
@@ -201,9 +201,9 @@ block I/O on a specific device. Specify the device and weight as ``<device path>
    # Container A - ten times less block IO priority as container A on disk /dev/sda
    $ singularity run --blkio-weight-device /dev/sda:100 mysecondapp.sif
 
-********************************************
- Applying Resource Limits From a TOML file
-********************************************
+******************************************
+Applying Resource Limits From a TOML file
+******************************************
 
 {Singularity} 3.9 and above can directly apply resource limitations to systems
 configured for both cgroups v1 and the v2 unified hierarchy, using the
@@ -227,7 +227,7 @@ configuration to be applied:
 
    $ singularity shell --apply-cgroups /path/to/cgroups.toml my_container.sif
 
-.. note:: 
+.. note::
 
    Using ``--apply-cgroups`` as a non-root user requires a cgroups v2 system,
    configured to use the ``systemd cgroups`` manager in ``singularity.conf``.
@@ -379,7 +379,7 @@ is specified in bytes per second.
 Device Limits
 =============
 
-.. note:: 
+.. note::
 
    Device limits can only be applied when running as the root user, and will be
    ignored as a non-root user.
@@ -417,9 +417,9 @@ https://github.com/opencontainers/runtime-spec/blob/master/config-linux.md#contr
 for information about the available limits. Note that {Singularity} uses
 TOML format for the configuration file, rather than JSON.
 
-**********************************************
- Applying Resource Limits With External Tools
-**********************************************
+********************************************
+Applying Resource Limits With External Tools
+********************************************
 
 Because {Singularity} starts a container as a simple process, rather
 than using a daemon, you can limit resource usage by running the

--- a/cli.rst
+++ b/cli.rst
@@ -1,8 +1,8 @@
 .. _cli:
 
-########################
- Command Line Interface
-########################
+######################
+Command Line Interface
+######################
 
 Below are links to the automatically generated CLI docs
 

--- a/cloud_library.rst
+++ b/cloud_library.rst
@@ -1,12 +1,12 @@
 .. _cloud_library:
 
-###############
- Cloud Library
-###############
+#############
+Cloud Library
+#############
 
-**********
- Overview
-**********
+********
+Overview
+********
 
 The Sylabs Cloud Library is the place to :ref:`push <push>` your
 containers to the cloud so other users can :ref:`pull <pull>`,
@@ -19,9 +19,9 @@ have root privileges.
 
 .. _make_a_account:
 
-*****************
- Make an Account
-*****************
+***************
+Make an Account
+***************
 
 Making an account is easy, and straightforward:
 
@@ -33,9 +33,9 @@ Making an account is easy, and straightforward:
 
 .. _creating_a_access_token:
 
-*************************
- Creating a Access token
-*************************
+***********************
+Creating a Access token
+***********************
 
 Access tokens for pushing a container, and remote builder.
 
@@ -56,9 +56,9 @@ Now that you have your token, you are ready to push your container!
 
 .. _push:
 
-*********************
- Pushing a Container
-*********************
+*******************
+Pushing a Container
+*******************
 
 The ``singularity push`` command will push a container to the container
 library with the given URL. Here's an example of a typical push command:
@@ -106,9 +106,9 @@ container in your web browser.
 
 .. _pull:
 
-*********************
- Pulling a container
-*********************
+*******************
+Pulling a container
+*******************
 
 The ``singularity pull`` command will download a container from the
 `Library <https://cloud.sylabs.io/library>`_ (``library://``), `Docker
@@ -165,9 +165,9 @@ etc...
    automatically, but it's good practice to always specify your output
    file.
 
-****************************
- Verify/Sign your Container
-****************************
+**************************
+Verify/Sign your Container
+**************************
 
 Verify containers that you pull from the library, ensuring they are
 bit-for-bit reproductions of the original image.
@@ -178,9 +178,9 @@ sign your own containers <sign_your_own_containers>`.
 
 .. _search_the_library:
 
-**************************************
- Searching the Library for Containers
-**************************************
+************************************
+Searching the Library for Containers
+************************************
 
 To find interesting or useful containers in the library, you can open
 https://cloud.sylabs.io/library in your browser and search from there
@@ -275,9 +275,9 @@ You can also limit results to only signed containers with the
 
 .. _remote_builder:
 
-****************
- Remote Builder
-****************
+**************
+Remote Builder
+**************
 
 The remote builder service can build your container in the cloud
 removing the requirement for root access.

--- a/contributing.rst
+++ b/contributing.rst
@@ -1,17 +1,17 @@
 .. _contributing:
 
-##############
- Contributing
-##############
+############
+Contributing
+############
 
 {Singularity} is an open source project, meaning we have the challenge
 of limited resources. We are grateful for any support that you can
 offer. Helping other users, raising issues, helping write documentation,
 or contributing code are all ways to help!
 
-********************
- Join the community
-********************
+******************
+Join the community
+******************
 
 This is a huge endeavor, and your help would be greatly appreciated!
 Post to online communities about {Singularity}, and request that your
@@ -36,9 +36,9 @@ find us at `singularityce.slack.com
 
 .. _report-a-issue:
 
-****************
- Raise an Issue
-****************
+**************
+Raise an Issue
+**************
 
 For general bugs/issues, you can open an issue `at the GitHub repo
 <https://github.com/sylabs/singularity/issues/new>`_. However, if you
@@ -47,9 +47,9 @@ security@sylabs.io. More information about the Sylabs security policies
 and procedures can be found `here
 <https://www.sylabs.io/singularity/security-policy/>`__
 
-*********************
- Write Documentation
-*********************
+*******************
+Write Documentation
+*******************
 
 We (like almost all open source software providers) have a documentation
 dilemma… We tend to focus on the code features and functionality before
@@ -86,9 +86,9 @@ identical for contributions to the documentation and the code base.
 
 .. _contribute-to-the-code:
 
-************************
- Contribute to the code
-************************
+**********************
+Contribute to the code
+**********************
 
 We use the traditional `GitHub Flow
 <https://guides.github.com/introduction/flow/>`_ to develop. This means

--- a/encryption.rst
+++ b/encryption.rst
@@ -1,15 +1,15 @@
 .. _encryption:
 
-######################
- Encrypted Containers
-######################
+####################
+Encrypted Containers
+####################
 
 Users can build a secure, confidential container environment by
 encrypting the root file system.
 
-**********
- Overview
-**********
+********
+Overview
+********
 
 In {Singularity} >= v3.4.0 a new feature to build and run encrypted
 containers has been added to allow users to encrypt the file system
@@ -28,9 +28,9 @@ at runtime completely within kernel space.
    Ubuntu 18.04, Debian 10 and CentOS/RHEL 7, but users of older Linux
    versions may have to update.
 
-************************
- Encrypting a container
-************************
+**********************
+Encrypting a container
+**********************
 
 A container can be encrypted either by supplying a plaintext passphrase
 or a PEM file containing an asymmetric RSA public key. Of these two
@@ -169,9 +169,9 @@ In this case it is necessary to use the ``--encrypt`` flag since the
 presence of an environment variable alone will not trigger the encrypted
 build workflow.
 
-********************************
- Running an encrypted container
-********************************
+******************************
+Running an encrypted container
+******************************
 
 To ``run``, ``shell``, or ``exec`` an encrypted image, credentials to
 decrypt the image need to be supplied at runtime either in a key-file or

--- a/endpoint.rst
+++ b/endpoint.rst
@@ -2,9 +2,9 @@
  Remote Endpoints
 ##################
 
-**********
- Overview
-**********
+********
+Overview
+********
 
 The ``remote`` command group allows users to manage the service
 endpoints {Singularity} will interact with for many common command
@@ -15,9 +15,9 @@ endpoints managed by this command group: the public Sylabs Cloud (or
 local {Singularity} Enterprise installation), OCI registries and
 keyservers.
 
-*********************
- Public Sylabs Cloud
-*********************
+*******************
+Public Sylabs Cloud
+*******************
 
 Sylabs introduced the online `Sylabs Cloud
 <https://cloud.sylabs.io/home>`_ to enable users to `Create
@@ -91,9 +91,9 @@ You can interact with the public Sylabs Cloud using various
    Using ``docker://``, ``oras://`` and ``shub://`` URIs with these
    commands does not interact with the Sylabs Cloud.
 
-***************************
- Managing Remote Endpoints
-***************************
+*************************
+Managing Remote Endpoints
+*************************
 
 Users can setup and switch between multiple remote endpoints, which are
 stored in their ``~/.singularity/remote.yaml`` file. Alternatively,
@@ -337,9 +337,9 @@ If you do not want to switch remote with ``remote use`` you can:
    ``--builder`` option.
 -  Make ``keys`` use an alternative keyserver with the ``-url`` option.
 
-**************************
- Keyserver Configurations
-**************************
+************************
+Keyserver Configurations
+************************
 
 By default, {Singularity} will use the keyserver correlated to the
 active cloud service endpoint. This behavior can be changed or
@@ -467,9 +467,9 @@ Now we can see that ``https://pgp.example.com`` is logged in:
 
 .. _sec:managing_oci_registries:
 
-*************************
- Managing OCI Registries
-*************************
+***********************
+Managing OCI Registries
+***********************
 
 It is common for users of {Singularity} to use OCI registries as sources
 for their container images. Some registries require credentials to

--- a/environment_and_metadata.rst
+++ b/environment_and_metadata.rst
@@ -1,8 +1,8 @@
 .. _environment-and-metadata:
 
-##########################
- Environment and Metadata
-##########################
+########################
+Environment and Metadata
+########################
 
 .. _sec:envandmetadata:
 
@@ -22,9 +22,9 @@ details such as the version of {Singularity} used are present as
 :ref:`labels <sec:labels>` on a container. You can also specify your own
 to be recorded against your container.
 
-**********************
- Environment Overview
-**********************
+********************
+Environment Overview
+********************
 
 When you run a program in a container with {Singularity}, the
 environment variables that the program sees are a combination of:
@@ -61,9 +61,9 @@ If you are interested in variables available when you are *building* a
 container, rather than when running a container, see :ref:`build
 environment section <build-environment>`.
 
-*******************************
- Environment From a Base Image
-*******************************
+*****************************
+Environment From a Base Image
+*****************************
 
 When you build a container with {Singularity} you might *bootstrap* from
 a library or Docker image, or using Linux distribution bootstrap tools
@@ -91,9 +91,9 @@ You can override the inherited environment with ``SINGULARITYENV_`` vars, or the
 ``--env / --env-file`` flags (see below), but ``Dockerfile`` ``ENV`` vars will
 not be overridden by host environment variables of the same name.
 
-************************************
- Environment From a Definition File
-************************************
+**********************************
+Environment From a Definition File
+**********************************
 
 Environment variables can be included in your container by adding them
 to your definition file. Use ``export`` in the ``%environment`` section
@@ -144,9 +144,9 @@ Variables set in the ``%post`` section through
 ``$SINGULARITY_ENVIRONMENT`` take precedence over those added via
 ``%environment``.
 
-***************************
- Environment From the Host
-***************************
+*************************
+Environment From the Host
+*************************
 
 If you have environment variables set outside of your container, on the
 host, then by default they will be available inside the container.
@@ -209,9 +209,9 @@ environment variables for correct operation of most software.
    such as ``PYTHONPATH`` that can change the way code runs, and
    consider using ``--cleanenv``.
 
-********************************************
- Environment From the {Singularity} Runtime
-********************************************
+******************************************
+Environment From the {Singularity} Runtime
+******************************************
 
 It can be useful for a program to know when it is running in a
 {Singularity} container, and some basic information about the container
@@ -234,9 +234,9 @@ program running in the container.
       requested, via flags or environment variables, when running the
       container.
 
-**********************************
- Overriding Environment Variables
-**********************************
+********************************
+Overriding Environment Variables
+********************************
 
 You can override variables that have been set in the container image, or
 define additional variables, in various ways as appropriate for your
@@ -514,9 +514,9 @@ environment is constructed in the following order:
 
 .. _sec:umask:
 
-**********************************
- Umask / Default File Permissions
-**********************************
+********************************
+Umask / Default File Permissions
+********************************
 
 The ``umask`` value on a Linux system controls the default permissions
 for newly created files. It is not an environment variable, but
@@ -546,9 +546,9 @@ the value outside, unless:
 
 .. _sec:metadata:
 
-********************
- Container Metadata
-********************
+******************
+Container Metadata
+******************
 
 Each {Singularity} container has metadata describing the container, how
 it was built, etc. This metadata includes the definition file used to
@@ -861,9 +861,9 @@ And the output would look like:
            "type": "container"
    }
 
-***************************
- /.singularity.d directory
-***************************
+*************************
+/.singularity.d directory
+*************************
 
 The ``/.singularity.d`` directory in a container contains scripts and
 environment files that are used when a container is executed.

--- a/fakeroot.rst
+++ b/fakeroot.rst
@@ -1,12 +1,12 @@
 .. _fakeroot:
 
-##################
- Fakeroot feature
-##################
+################
+Fakeroot feature
+################
 
-**********
- Overview
-**********
+********
+Overview
+********
 
 The fakeroot feature (commonly referred as rootless mode) allows an
 unprivileged user to run a container as a **"fake root"** user by
@@ -28,9 +28,9 @@ which means that this user:
    -  has full privileges inside the requested namespaces (network, ipc,
       uts)
 
-***********************
- Restrictions/security
-***********************
+*********************
+Restrictions/security
+*********************
 
 Filesystem
 ==========
@@ -90,9 +90,9 @@ the host network.
    no`` is set in ``singularity.conf`` users won't be able to use a
    ``fakeroot`` network.
 
-******************************
- Requirements / Configuration
-******************************
+****************************
+Requirements / Configuration
+****************************
 
 Fakeroot depends on user mappings set in ``/etc/subuid`` and group
 mappings in ``/etc/subgid``, so your username needs to be listed in
@@ -106,9 +106,9 @@ be a root user or run with ``sudo`` to use ``config fakeroot``, as the
 mapping files are security sensitive. See the admin-guide for more
 details.
 
-*******
- Usage
-*******
+*****
+Usage
+*****
 
 If your user account is configured with valid ``subuid`` and ``subgid``
 mappings you work as a fake root user inside a container by using the

--- a/gpu.rst
+++ b/gpu.rst
@@ -1,8 +1,8 @@
 .. _gpu:
 
-######################################
- GPU Support (NVIDIA CUDA & AMD ROCm)
-######################################
+####################################
+GPU Support (NVIDIA CUDA & AMD ROCm)
+####################################
 
 {Singularity} natively supports running application containers that use
 NVIDIA's CUDA GPU compute framework, or AMD's ROCm solution. This allows
@@ -21,9 +21,9 @@ functionality, accessible via the new ``--nvccli`` flag, improves
 compatibility with OCI runtimes and exposes additional container
 configuration options.
 
-*****************************
- NVIDIA GPUs & CUDA (Legacy)
-*****************************
+***************************
+NVIDIA GPUs & CUDA (Legacy)
+***************************
 
 Commands that ``run``, or otherwise execute containers (``shell``,
 ``exec``) can take an ``--nv`` option, which will setup the container's
@@ -190,9 +190,9 @@ driver stack on the host first, by running a CUDA program there or
 ``modprobe nvidia_uvm`` as root, and using ``nvidia-persistenced`` to
 avoid driver unload.
 
-*******************************************
- NVIDIA GPUs & CUDA (nvidia-container-cli)
-*******************************************
+*****************************************
+NVIDIA GPUs & CUDA (nvidia-container-cli)
+*****************************************
 
 {Singularity} 3.9 introduces the ``--nvccli`` option, which will
 instruct {Singularity} to perform GPU container setup using the
@@ -391,9 +391,9 @@ be found in the container-toolkit guide:
 
 https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/user-guide.html#environment-variables-oci-spec
 
-*****************
- AMD GPUs & ROCm
-*****************
+***************
+AMD GPUs & ROCm
+***************
 
 {Singularity} 3.5 adds a ``--rocm`` flag to support GPU compute with the
 ROCm framework using AMD Radeon GPU cards.
@@ -486,9 +486,9 @@ tensorflow ``list_local_devices()`` function:
    pciBusID 0000:09:00.0
    ...
 
-*********************
- OpenCL Applications
-*********************
+*******************
+OpenCL Applications
+*******************
 
 Both the ``--rocm`` and ``--nv`` flags will bind the vendor OpenCL
 implementation libraries into a container that is being run. However,

--- a/index.rst
+++ b/index.rst
@@ -12,9 +12,9 @@ For a detailed guide to installation and configuration, please see the
 separate Admin Guide for this version of {Singularity} at
 https://sylabs.io/guides/{adminversion}/admin-guide/.
 
-******************************************
- Getting Started & Background Information
-******************************************
+****************************************
+Getting Started & Background Information
+****************************************
 
 .. toctree::
    :maxdepth: 2
@@ -23,9 +23,9 @@ https://sylabs.io/guides/{adminversion}/admin-guide/.
    Quick Start <quick_start>
    Security in {Singularity} <security>
 
-*********************
- Building Containers
-*********************
+*******************
+Building Containers
+*******************
 
 Learn how to write a definition file that can be used to build a
 container. Understand the environment within a build, how to perform
@@ -40,9 +40,9 @@ non-root user.
    Build Environment <build_env>
    Fakeroot feature <fakeroot>
 
-********************************
- Container Signing & Encryption
-********************************
+******************************
+Container Signing & Encryption
+******************************
 
 {Singularity} allows containers to be signed using a PGP key. The
 signature travels with the container image, allowing you to verify that
@@ -57,9 +57,9 @@ decrypting them to disk first.
    Key management commands <key_commands>
    Encrypted Containers <encryption>
 
-***************************
- Sharing & Online Services
-***************************
+*************************
+Sharing & Online Services
+*************************
 
 Sylabs offers a suite of container services, with a free tier and
 on-premise options. Learn how to make use these services to simplify the
@@ -71,9 +71,9 @@ process of building, signing, and sharing your containers.
    Remote Endpoints <endpoint>
    Sylabs Cloud Library <cloud_library>
 
-****************
- Advanced Usage
-****************
+**************
+Advanced Usage
+**************
 
 Once you've understood the basics, explore all the options which
 {Singularity} provides for accessing data, running persistent services
@@ -92,9 +92,9 @@ networking and security configuration.
    Network Options <networking>
    Limiting Container Resources <cgroups>
 
-***************
- Compatibility
-***************
+*************
+Compatibility
+*************
 
 {Singularity} has unique benefits and supports easy access to GPUs and
 other hardware. It also strives for compatibility with Docker/OCI
@@ -109,9 +109,9 @@ Docker, as well as how to use containerized MPI and GPU applications.
    Singularity and MPI applications <mpi>
    GPU Support <gpu>
 
-**************
- Get Involved
-**************
+************
+Get Involved
+************
 
 We'd love you to get involved in the {Singularity} community! Whether
 through contributing feature and fixes, helping to answer questions from
@@ -122,9 +122,9 @@ other users, or simply testing new releases.
 
    Contributing <contributing>
 
-***********
- Reference
-***********
+*********
+Reference
+*********
 
 .. toctree::
    :maxdepth: 2

--- a/key_commands.rst
+++ b/key_commands.rst
@@ -1,8 +1,8 @@
 .. _key_commands:
 
-##############
- Key commands
-##############
+############
+Key commands
+############
 
 .. _sec:key_commands:
 
@@ -13,9 +13,9 @@ the local keyring and are not related to the cloud keystore.
 
 .. _key_import:
 
-******************************
- Changes in {Singularity} 3.7
-******************************
+****************************
+Changes in {Singularity} 3.7
+****************************
 
 {Singularity} 3.7 introduces a global keyring which can be managed by
 administrators with the new ``--global`` option. This global keyring is
@@ -24,9 +24,9 @@ used by ECL
 and allows administrators to manage public keys used during ECL image
 verification.
 
-********************
- Key import command
-********************
+******************
+Key import command
+******************
 
 {Singularity} 3.2 allows you import keys reading either from binary or
 armored key format and automatically detect if it is a private or public
@@ -136,9 +136,9 @@ detected by the ``key import`` command (no need to specify the format).
 
 .. _key_export:
 
-********************
- Key export command
-********************
+******************
+Key export command
+******************
 
 The key export command allows you to export a key that is on your local
 keystore. This key could be either private or public, and the key can be
@@ -188,9 +188,9 @@ and on binary format instead:
 
 .. _key_remove:
 
-********************
- Key remove command
-********************
+******************
+Key remove command
+******************
 
 In case you would want to remove a public key from your public local
 keystore, you can do so by running the following command:

--- a/license.rst
+++ b/license.rst
@@ -2,18 +2,18 @@
  Licenses
 ##########
 
-***************
- Documentation
-***************
+*************
+Documentation
+*************
 
 This documentation is subject to the following 3-clause BSD license:
 
 .. include:: LICENSE
    :literal:
 
-************************
- {Singularity} Software
-************************
+**********************
+{Singularity} Software
+**********************
 
 .. mdinclude:: singularity_source/LICENSE.md
 

--- a/mpi.rst
+++ b/mpi.rst
@@ -1,8 +1,8 @@
 .. _mpi:
 
-####################################
- {Singularity} and MPI applications
-####################################
+##################################
+{Singularity} and MPI applications
+##################################
 
 .. _sec-mpi:
 
@@ -34,9 +34,9 @@ host into the container.
    disabled by system administrators for operational reasons. If this is
    the case on your system please follow the *hybrid* approach.
 
-**************
- Hybrid model
-**************
+************
+Hybrid model
+************
 
 The basic idea behind the *Hybrid Approach* is when you execute a
 {Singularity} container with MPI code, you will call ``mpiexec`` or a
@@ -277,9 +277,9 @@ when the containers start, the MPI binary is executed:
    Hello, I am rank 1/8
    Hello, I am rank 7/8
 
-************
- Bind model
-************
+**********
+Bind model
+**********
 
 Similar to the *Hybrid Approach*, the basic idea behind the *Bind
 Approach* is to start the MPI application by calling the MPI launcher
@@ -393,9 +393,9 @@ to run the container in bind mode are:
    Hello, I am rank 4/8
    Hello, I am rank 6/8
 
-*************************
- Batch Scheduler / Slurm
-*************************
+***********************
+Batch Scheduler / Slurm
+***********************
 
 If your target system is setup with a batch system such as SLURM, a
 standard way to execute MPI applications is through a batch script. The
@@ -426,9 +426,9 @@ A user can then submit a job by executing the following SLURM command:
 
    $ sbatch my_job.sh
 
-***********************
- Alternative Launchers
-***********************
+*********************
+Alternative Launchers
+*********************
 
 On many systems it is common to use an alternative launcher to start MPI
 applications, e.g. Slurm's ``srun`` rather than the ``mpirun`` provided
@@ -440,9 +440,9 @@ launcher.
 In the bind mode the host MPI is used in the container, and should
 interact correctly with the same launchers as it does on the host.
 
-****************************
- Interconnects / Networking
-****************************
+**************************
+Interconnects / Networking
+**************************
 
 High performance interconnects such as Infiniband and Omnipath require
 that MPI implementations are built to support them. You may need to
@@ -455,9 +455,9 @@ container. If you run a container using the ``--contain`` or
 to bind in additional ``/dev/`` entries manually to support the
 operation of your interconnect drivers in the container in this case.
 
-**********************
- Troubleshooting Tips
-**********************
+********************
+Troubleshooting Tips
+********************
 
 If your containers run N rank 0 processes, instead of operating
 correctly as an MPI application, it is likely that the MPI stack used to

--- a/networking.rst
+++ b/networking.rst
@@ -1,8 +1,8 @@
 .. _networking:
 
-########################
- Network virtualization
-########################
+######################
+Network virtualization
+######################
 
 .. _sec:networking:
 
@@ -23,9 +23,9 @@ configure a virtualized network for a container.
    configurations. This is accomplished through settings in
    ``singularity.conf``. See the administrator guide for details.
 
-***********
- ``--dns``
-***********
+*********
+``--dns``
+*********
 
 The ``--dns`` option allows you to specify a comma separated list of DNS
 servers to add to the ``/etc/resolv.conf`` file.
@@ -41,9 +41,9 @@ servers to add to the ``/etc/resolv.conf`` file.
    $ sudo singularity exec --dns 8.8.8.8 ubuntu.sif cat /etc/resolv.conf
    nameserver 8.8.8.8
 
-****************
- ``--hostname``
-****************
+**************
+``--hostname``
+**************
 
 The ``--hostname`` option accepts a string argument to change the
 hostname within the container.
@@ -56,9 +56,9 @@ hostname within the container.
    $ sudo singularity exec --hostname hal-9000 my_container.sif hostname
    hal-9000
 
-***********
- ``--net``
-***********
+*********
+``--net``
+*********
 
 Passing the ``--net`` flag will cause the container to join a new
 network namespace when it initiates. New in {Singularity} 3.0, a bridge
@@ -72,9 +72,9 @@ interface will also be set up by default.
    $ sudo singularity exec --net my_container.sif hostname -I
    10.22.0.4
 
-***************
- ``--network``
-***************
+*************
+``--network``
+*************
 
 The ``--network`` option can only be invoked in combination with the
 ``--net`` flag. It accepts a comma delimited string of network types.
@@ -114,9 +114,9 @@ Additional cni configuration files can be added to the ``network``
 configuration directory as required, and {Singularity}'s provided
 configurations may also be modified.
 
-********************
- ``--network-args``
-********************
+******************
+``--network-args``
+******************
 
 The ``--network-args`` option provides a convenient way to specify
 arguments to pass directly to the cni plugins. It must be used in

--- a/persistent_overlays.rst
+++ b/persistent_overlays.rst
@@ -7,9 +7,9 @@ system on an immutable read-only container for the illusion of
 read-write access. You can run a container and make changes, and these
 changes are kept separately from the base container image.
 
-**********
- Overview
-**********
+********
+Overview
+********
 
 A persistent overlay is a directory or file system image that “sits on
 top” of your immutable SIF container. When you install new software or
@@ -40,9 +40,9 @@ You can use persistent overlays with the following commands:
 -  ``shell``
 -  ``instance start``
 
-*******
- Usage
-*******
+*****
+Usage
+*****
 
 To use a persistent overlay, you must first have a container.
 
@@ -107,10 +107,10 @@ space on disk that the file is currently using:
 
 .. code::
 
-   $ ls -lah /tmp/ext3_overlay.img 
+   $ ls -lah /tmp/ext3_overlay.img
    -rw-------. 1 dtrudg-sylabs dtrudg-sylabs 1.0G Jan 27 11:47 /tmp/ext3_overlay.img
 
-   $ du -h /tmp/ext3_overlay.img 
+   $ du -h /tmp/ext3_overlay.img
    33M     /tmp/ext3_overlay.img
 
 If you copy or move the sparse image you should ensure that the tool you use to
@@ -218,7 +218,7 @@ Overlay embedded in SIF
 
 It is possible to embed an overlay image into the SIF file that holds a
 container. This allows the read-only container image and your
-modifications to it to be managed as a single file. 
+modifications to it to be managed as a single file.
 
 To add a 1 GiB writable overlay partition to an existing SIF image:
 

--- a/plugins.rst
+++ b/plugins.rst
@@ -1,16 +1,16 @@
 .. _plugins:
 
-#########
- Plugins
-#########
+#######
+Plugins
+#######
 
-**********
- Overview
-**********
+********
+Overview
+********
 
 A {Singularity} plugin is a package that can be dynamically loaded by the
 {Singularity} runtime, augmenting {Singularity} with experimental, non-standard
-and/or vendor-specific functionality. 
+and/or vendor-specific functionality.
 
 Plugins can influence the behaviour of {Singularity} in specific ways:
 
@@ -26,9 +26,9 @@ Plugins can influence the behaviour of {Singularity} in specific ways:
 * A runtime plugin can use the ``RegisterImageDriver`` callback to implement an
   alternative way of providing a container image to execute.
 
-****************************
- Limitations / Requirements
-****************************
+**************************
+Limitations / Requirements
+**************************
 
 The way that plugin functionality is implemented in the Go language, which
 {Singularity} is written with, is quite restrictive.
@@ -48,9 +48,9 @@ investigate whether the feature can be contributed to the main source tree
 directly via a PR. This simplifies future maintenance, and avoids the
 limitations of Go plugins.
 
-***************
- Using Plugins
-***************
+*************
+Using Plugins
+*************
 
 The ``list`` command prints the currently installed plugins.
 
@@ -82,8 +82,8 @@ plugin's source code.
 
    Due to the structure of the {Singularity} project, and the strict
    requirements of Go plugin compilation, **all** plugins must be compiled from
-   within the {Singularity} source code tree. 
-   
+   within the {Singularity} source code tree.
+
    The ability to compile plugins outside of the {Singularity} tree, that
    previously existed, has been removed due to incompatible changes in Go 1.18.
 
@@ -137,9 +137,9 @@ operation requires root privilege.
    $ singularity plugin list
    There are no plugins installed.
 
-******************
- Writing a Plugin
-******************
+****************
+Writing a Plugin
+****************
 
 Developers interested in writing {Singularity} plugins can get started
 by reading the `Go documentation

--- a/quick_start.rst
+++ b/quick_start.rst
@@ -778,9 +778,9 @@ https://www.sylabs.io/contact/
 
 .. _installation-request:
 
-***********************************
- {Singularity} on a shared resource
-***********************************
+*********************************
+{Singularity} on a shared resource
+*********************************
 
 Perhaps you are a user who wants a few talking points and background to
 share with your administrator. Or maybe you are an administrator who

--- a/security_options.rst
+++ b/security_options.rst
@@ -1,8 +1,8 @@
 .. _security-options:
 
-##################
- Security Options
-##################
+################
+Security Options
+################
 
 .. _sec:security_options:
 
@@ -11,9 +11,9 @@ container runtime. This document will describe the new methods users
 have for specifying the security scope and context when running
 {Singularity} containers.
 
-********************
- Linux Capabilities
-********************
+******************
+Linux Capabilities
+******************
 
 .. note::
 
@@ -102,9 +102,9 @@ The ``--add-caps`` and ``--drop-caps`` options will accept the ``all``
 keyword. Of course appropriate caution should be exercised when using
 this keyword.
 
-*******************************
- Building encrypted containers
-*******************************
+*****************************
+Building encrypted containers
+*****************************
 
 Beginning in {Singularity} 3.4.0 it is possible to build and run
 encrypted containers. The containers are decrypted at runtime entirely
@@ -112,9 +112,9 @@ in kernel space, meaning that no intermediate decrypted data is ever
 present on disk. See :ref:`encrypted containers <encryption>` for more
 details.
 
-*********************************
- Security related action options
-*********************************
+*******************************
+Security related action options
+*******************************
 
 {Singularity} 3.0 introduces many new flags that can be passed to the
 action commands; ``shell``, ``exec``, and ``run`` allowing fine grained

--- a/singularity_and_docker.rst
+++ b/singularity_and_docker.rst
@@ -1,8 +1,8 @@
 .. _singularity-and-docker:
 
-#######################################
- Support for Docker and OCI Containers
-#######################################
+#####################################
+Support for Docker and OCI Containers
+#####################################
 
 The Open Containers Initiative (OCI) container format, which grew out of
 Docker, is the dominant standard for cloud-focused containerized
@@ -35,9 +35,9 @@ improved compatibility in some cases. Special requirements and limitations
 apply, which will be addressed through version 4.0. Please :ref:`consult the
 documentation <oci_mode>` about ``--oci`` mode for more information.
 
-****************************
- Containers From Docker Hub
-****************************
+**************************
+Containers From Docker Hub
+**************************
 
 Docker Hub is the most common place that projects publish public
 container images. At some point, it's likely that you will want to run
@@ -208,9 +208,9 @@ set for both ``singularity`` and ``docker`` operations.
    $ export SINGULARITY_DOCKER_PASSWORD=mytoken
    $ singularity pull docker://sylabsio/private
 
-**********************************
- Containers From Other Registries
-**********************************
+********************************
+Containers From Other Registries
+********************************
 
 You can use ``docker://`` URIs with {Singularity} to pull and run
 containers from OCI registries other than Docker Hub. To do this, you'll
@@ -399,9 +399,9 @@ which details how to use ``az acr token create`` to obtain a token name
 and password pair that can be used to authenticate with the above
 methods.
 
-***************************************
- Building From Docker / OCI Containers
-***************************************
+*************************************
+Building From Docker / OCI Containers
+*************************************
 
 If you wish to use an existing Docker or OCI container as the basis for
 a new container, you will need to specify it as the *bootstrap* source
@@ -631,9 +631,9 @@ filename in the ``From:`` line:
 
 .. _sec:optional_headers_def_files:
 
-***************************************
- Differences and Limitations vs Docker
-***************************************
+*************************************
+Differences and Limitations vs Docker
+*************************************
 
 Though Docker / OCI container compatibility is a goal of {Singularity},
 there are some differences and limitations due to the way {Singularity}
@@ -920,9 +920,9 @@ around this, use the ``--no-init`` flag to disable the shim:
 
 .. _compat-flag:
 
-*******************************
- Docker-like ``--compat`` Flag
-*******************************
+*****************************
+Docker-like ``--compat`` Flag
+*****************************
 
 If Docker-like behavior is important, {Singularity} can be started with
 the ``--compat`` flag. This flag is a convenient short-hand alternative
@@ -956,9 +956,9 @@ execute correctly under {Singularity}. The user namespace and network
 namespace are not used, as these negate benefits of SIF and direct
 access to high performance cluster networks.
 
-****************************
- CMD / ENTRYPOINT Behaviour
-****************************
+**************************
+CMD / ENTRYPOINT Behaviour
+**************************
 
 When a container is run using ``docker``, its default behavior depends
 on the ``CMD`` and/or ``ENTRYPOINT`` set in the ``Dockerfile`` that was
@@ -1078,9 +1078,9 @@ runtimes as there is no evaluated runscript.
 
 .. _sec:best_practices:
 
-*********************************************************
- Best Practices for Docker & {Singularity} Compatibility
-*********************************************************
+*******************************************************
+Best Practices for Docker & {Singularity} Compatibility
+*******************************************************
 
 As detailed previously, {Singularity} can make use of most Docker and
 OCI images without issues, or via simple workarounds. In general,
@@ -1144,9 +1144,9 @@ creating Docker / OCI containers that will also be run using
 
 .. _sec:troubleshooting:
 
-*****************
- Troubleshooting
-*****************
+***************
+Troubleshooting
+***************
 
 Registry Authentication Issues
 ==============================
@@ -1203,9 +1203,9 @@ you believe they are due to a bug in {Singularity}.
 
 .. _sec:deffile-vs-dockerfile:
 
-**********************************************
- {Singularity} Definition file vs. Dockerfile
-**********************************************
+********************************************
+{Singularity} Definition file vs. Dockerfile
+********************************************
 
 An alternative to running Docker containers with {Singularity} is to
 re-write the ``Dockerfile`` as a definition file, and build a native SIF


### PR DESCRIPTION
## Description of the Pull Request (PR):

Many of the headings in the reStructuredText source files have an extra space before the heading text, and two extra symbols in the overline and underline, reflecting outdated linting/formatting.

Updated to current style, where heading text is not preceded by any spaces, and overline and underline are exactly the length of heading text.

