### PR TITLE
Tidy up cwd/home mount explanation

### DIFF
--- a/quick_start.rst
+++ b/quick_start.rst
@@ -607,9 +607,10 @@ Files on the host are reachable from within the container:
    $ singularity exec lolcow_latest.sif cat $HOME/hostfile.txt
    Hello from inside the container
 
-This example works because ``hostfile.txt`` exists in the user's home
-directory. By default, {Singularity} bind mounts ``/home/$USER``,
-``/tmp``, and ``$PWD`` into your container at runtime.
+This example works because ``hostfile.txt`` exists in the user's home directory
+(``$HOME``). By default, {Singularity} bind mounts ``$HOME``, the current
+working directory, and additional system locations from the host into the
+container.
 
 You can specify additional directories to bind mount into your container
 with the ``--bind`` option. In this example, the ``data`` directory on


### PR DESCRIPTION
Note the situation in which CWD is not mounted, how to avoid mounting $HOME if CWD is under $HOME etc.

Correct /clarify some odd stuff around `--contain-all`

Fixes #189
