### PR TITLE
cgroups: fix "tenth" (of a CPU) unit to "hundredth" in desc. of --cpu

### DIFF
--- a/cgroups.rst
+++ b/cgroups.rst
@@ -84,8 +84,8 @@ CPU Limits
 ==========
 
 ``--cpus`` sets the number of CPUs, or fractional CPUs, that the container can
-use.  The minimum is ``0.01`` or one tenth of a physical CPU. The maximum is the
-number of CPU cores on your system.
+use.  The minimum is ``0.01`` or one hundredth of a physical CPU. The maximum is
+the number of CPU cores on your system.
 
 .. code::
 


### PR DESCRIPTION
## Description of the Pull Request (PR):

Fixes incorrect unit (in prose) for description of CPU limit (`--cpu` option) from "tenth" to "hundredth".

## This fixes or addresses the following GitHub issues:

- Fixes #211 
