### PR TITLE
repl. `remote` cmd with `registry` in "Support for Docker" page

### DIFF
--- a/singularity_and_docker.rst
+++ b/singularity_and_docker.rst
@@ -167,17 +167,17 @@ To make use of the API limits under a Docker Hub account, or to access
 private containers, you'll need to authenticate to Docker Hub. There are
 a number of ways to do this with {Singularity}.
 
-Singularity CLI Remote Command
-------------------------------
+Singularity CLI ``registry`` Command
+------------------------------------
 
-The ``singularity remote login`` command supports logging into Docker
+The ``singularity registry login`` command supports logging into Docker
 Hub and other OCI registries. For Docker Hub, the registry hostname is
 ``docker.io``, so you will need to login as below, specifying your
 username:
 
 .. code::
 
-   $ singularity remote login --username myuser docker://docker.io
+   $ singularity registry login --username myuser docker://docker.io
    Password / Token:
    INFO:    Token stored in /home/myuser/.singularity/remote.yaml
 
@@ -186,14 +186,14 @@ which you should generate in the 'Security' section of your account
 profile page on Docker Hub.
 
 To check which Docker / OCI registries you are currently logged in to,
-use ``singularity remote list``.
+use ``singularity registry list``.
 
 To logout of a registry, so that your credentials are forgotten, use
-``singularity remote logout``:
+``singularity registry logout``:
 
 .. code::
 
-   $ singularity remote logout docker://docker.io
+   $ singularity registry logout docker://docker.io
    INFO:    Logout succeeded
 
 Docker CLI Authentication
@@ -287,7 +287,7 @@ To pull containers from private repositories you will need to generate a
 CLI token in the Quay web interface, then use it to login with
 {Singularity}. Use the same methods as described for Docker Hub above:
 
--  Run ``singularity remote login --username myuser docker://quay.io``
+-  Run ``singularity registry login --username myuser docker://quay.io``
    to store your credentials for {Singularity}.
 -  Use ``docker login quay.io`` if ``docker`` is on your machine.
 -  Use the ``--docker-login`` flag for a one-time interactive login.
@@ -320,7 +320,7 @@ Use one of the following authentication methods (detailed above for
 Docker Hub), with the username ``$oauthtoken`` and the password set to
 your NGC API key.
 
--  Run ``singularity remote login --username \$oauthtoken
+-  Run ``singularity registry login --username \$oauthtoken
    docker://nvcr.io`` to store your credentials for {Singularity}.
 -  Use ``docker login nvcr.io`` if ``docker`` is on your machine.
 -  Use the ``--docker-login`` flag for a one-time interactive login.
@@ -352,7 +352,7 @@ documentation here.
 Use one of the following authentication methods (detailed above for
 Docker Hub), with your username and personal access token:
 
--  Run ``singularity remote login --username myuser docker://ghcr.io``
+-  Run ``singularity registry login --username myuser docker://ghcr.io``
    to store your credentials for {Singularity}.
 -  Use ``docker login ghcr.io`` if ``docker`` is on your machine.
 -  Use the ``--docker-login`` flag for a one-time interactive login.
@@ -386,7 +386,7 @@ username used in conjunction with this password is always ``AWS``.
 
 Then login using one of the following methods:
 
--  Run ``singularity remote login --username AWS
+-  Run ``singularity registry login --username AWS
    docker://<accountid>.dkr.ecr.<region>.amazonaws.com`` to store your
    credentials for {Singularity}.
 
@@ -419,7 +419,7 @@ will add credentials to ``.docker/config.json`` which can be read by
 Service Principle accounts will have an explicit username and password,
 and you should authenticate using one of the following methods:
 
--  Run ``singularity remote login --username myuser
+-  Run ``singularity registry login --username myuser
    docker://myregistry.azurecr.io`` to store your credentials for
    {Singularity}.
 
@@ -621,7 +621,7 @@ stored credentials or environment variables must be available to the
    environment variables through sudo to the ``root`` build process by
    running ``sudo -E singularity build ...``.
 
--  Run ``sudo singularity remote login ...`` to store your credentials
+-  Run ``sudo singularity registry login ...`` to store your credentials
    for the ``root`` user on your system. This is separate from storing
    the credentials under your own account.
 
@@ -1318,7 +1318,7 @@ If you experience problems pulling containers from a private registry,
 check your credentials carefully. You can ``singularity pull`` with the
 ``--docker-login`` flag to perform an interactive login. This may be
 useful if you are unsure whether you have stored credentials properly
-via ``singularity remote login`` or ``docker login``.
+via ``singularity registry login`` or ``docker login``.
 
 OCI registries expect different values for username and password fields.
 Some require a token to be generated and used instead of your account


### PR DESCRIPTION
## Description of the Pull Request (PR):

The "Support for Docker and OCI Containers" (singularity_and_docker.rst) was still referring to the `remote` command for functionality that has now been moved to the `registry` command (see https://github.com/sylabs/singularity/pull/1908).

This PR fixes those occurrences to `registry`, as appropriate.