### PR TITLE
build: doc'n support for --authfile flag

### DIFF
--- a/appendix.rst
+++ b/appendix.rst
@@ -42,6 +42,10 @@ below with their respective functionality.
    (e.g. ``arm64``) of an image to pull from a ``library://`` or OCI source.
    Defaults to the host architecture.
 
+#. **SINGULARITY_AUTHFILE**: Specify a non-standard location for storing /
+   reading login credentials for OCI/Docker registries. See the
+   :ref:`authfile documentation <sec:authfile>`.
+
 ``B``
 =====
 

--- a/registry.rst
+++ b/registry.rst
@@ -178,3 +178,24 @@ errors:
    WARNING: There is no existing login to registry "docker.io".
    INFO:    Logout succeeded
 
+SINGULARITY_AUTHFILE
+====================
+
+In lieu of using the ``--authfile`` command-line flag, the same functionality
+may be accessed by setting the ``SINGULARITY_AUTHFILE`` environment variable,
+both for the ``registry login`` / ``registry logout`` commands and for the `pull
+<https://www.sylabs.io/guides/{version}/user-guide/cli/singularity_pull.html>`__
+/ `push
+<https://www.sylabs.io/guides/{version}/user-guide/cli/singularity_push.html>`__
+/ `build
+<https://www.sylabs.io/guides/{version}/user-guide/cli/singularity_build.html>`__
+/ `exec
+<https://www.sylabs.io/guides/{version}/user-guide/cli/singularity_exec.html>`__
+/ `shell
+<https://www.sylabs.io/guides/{version}/user-guide/cli/singularity_shell.html>`__
+/ `run
+<https://www.sylabs.io/guides/{version}/user-guide/cli/singularity_run.html>`__
+/ `instance start
+<https://www.sylabs.io/guides/{version}/user-guide/cli/singularity_instance.html>`__
+set of commands.
+

--- a/registry.rst
+++ b/registry.rst
@@ -156,6 +156,15 @@ The same flag is also supported when using these commands in :ref:`OCI mode
    INFO:    Cleaning up.
    Singularity>
 
+.. note::
+
+   If ``SINGULARITY_DOCKER_{USERNAME,PASSWORD}`` or
+   ``DOCKER_{USERNAME,PASSWORD}`` environment variables are set, they will take
+   precedence over anything specified with the ``--authfile`` flag (or anything
+   specified with the ``SINGULARITY_AUTHFILE`` variable, discussed below). See
+   the :ref:`documentation of docker-related environment variables
+   <sec:docker_envvars>` for details.
+
 Finally, note that logging in when the relevant credentials already exist, and
 logging out when the relevant credentials are already absent, are not considered
 errors:

--- a/singularity_and_docker.rst
+++ b/singularity_and_docker.rst
@@ -227,6 +227,8 @@ credentials, use the ``--docker-login`` flag:
    Enter Docker Username: myuser
    Enter Docker Password:
 
+.. _sec:docker_envvars:
+
 Environment Variables
 ---------------------
 

--- a/singularity_and_docker.rst
+++ b/singularity_and_docker.rst
@@ -614,9 +614,10 @@ ensure that the credentials needed to access the image are available to
 A build might be run as the ``root`` user, e.g. via ``sudo``, or under
 your own account with ``--fakeroot``.
 
-If you are running the build as ``root``, using ``sudo``, then any
-stored credentials or environment variables must be available to the
-``root`` user:
+If you are running the build as ``root``, using ``sudo``, then any stored
+credentials or environment variables must be available to the ``root`` user. You
+can make the credentials available to the ``root`` user in one of the following
+ways:
 
 -  Use the ``--docker-login`` flag for a one-time interactive login.
    I.E. run ``sudo singularity build --docker-login myimage.sif
@@ -633,6 +634,14 @@ stored credentials or environment variables must be available to the
 
 -  Use ``sudo docker login`` if ``docker`` is on your machine. This is
    separate from storing the credentials under your own account.
+
+-  Store the credentials in a custom file on your filesystem using the
+   ``registry login --authfile <path>`` subcommand, and then pass the same
+   ``--authfile <path>`` flag to the ``build`` command. Note, however, that this
+   will store the relevant credentials unencrypted in the specified file, so
+   appropriate care must be taken concerning the location, ownership, and
+   permissions of this file. See the :ref:`documentation of the --authfile flag
+   <sec:authfile>` for more information.
 
 If you are running the build under your account via the ``--fakeroot``
 feature you do not need to specially set credentials for the root user.


### PR DESCRIPTION
## Description of the Pull Request (PR):

Document the changes made as part of https://github.com/sylabs/singularity/pull/2238, adding support for the `--authfile` flag for (non-remote) `build` command.

