### PR TITLE
docs: build from Dockerfiles

### DIFF
--- a/appendix.rst
+++ b/appendix.rst
@@ -1124,7 +1124,7 @@ where both ``<image>`` and ``<tag>`` are mandatory fields that must be
 written explicitly.
 
 
-.. _docker-daemon:
+.. _docker-archive:
 
 ``docker-archive`` bootstrap agent
 ==================================

--- a/build_a_container.rst
+++ b/build_a_container.rst
@@ -464,6 +464,50 @@ Build from Dockerfiles supports many of the same command-line options as regular
   ``--authfile``: see the documentation on :ref:`authenticating with Docker/OCI
   registries <docker_auth>` and on the :ref:`authfile flag <sec:authfile>`.
 
+* ``--arch``: build a container for a different CPU architecture than that of
+  the running host.
+  
+As an example, if you are running on an ``amd64`` machine, you can run the
+following to build a container image for the 64-bit ARM architecure:
+
+.. code:: console
+
+   $ singularity build --arch arm64 --oci ./alpine.oci.sif ./Dockerfile.alpine
+   INFO:    Did not find usable running buildkitd daemon; spawning our own.
+   INFO:    cfg.Root for buildkitd: /home/omer/.local/share/buildkit
+   INFO:    Using "crun" runtime for buildkitd daemon.
+   INFO:    running buildkitd server on /run/user/1000/buildkit/buildkitd-4747966236261602.sock
+   [+] Building 0.6s (1/2)
+   [+] Building 0.7s (5/5) FINISHED
+   => [internal] load build definition from Dockerfile.alpine     0.0s
+   => => transferring dockerfile: 142B                               0.0s
+   => [internal] load metadata for docker.io/library/alpine:latest   0.6s
+   => [internal] load .dockerignore                                  0.0s
+   => => transferring context: 2B                                    0.0s
+   => CACHED [1/1] FROM docker.io/library/alpine:latest@sha256:eece  0.0s
+   => => resolve docker.io/library/alpine:latest@sha256:eece025e432  0.0s
+   => exporting to docker image format                               0.0s
+   => => exporting layers                                            0.0s
+   => => exporting manifest sha256:b799c38cef1756bcc55b0684617fda7d  0.0s
+   => => exporting config sha256:5118299610d621e305a9153753a52e2f9e  0.0s
+   => => sending tarball                                             0.0s
+   Getting image source signatures
+   Copying blob 579b34f0a95b done   |
+   Copying config 5a13726077 done   |
+   Writing manifest to image destination
+   INFO:    Converting OCI image to OCI-SIF format
+   INFO:    Squashing image to single layer
+   INFO:    Writing OCI-SIF image
+   INFO:    Cleaning up.
+   INFO:    Build complete: ./alpine.oci.sif
+
+.. note::
+
+   In order to use Dockerfile directives like ``RUN`` in a cross-architecture
+   build, you will have to have ``qemu-static`` / ``binfmt_misc`` emulation
+   installed. See the discussion of :ref:`CPU emulation <qemu>` for more
+   information.
+
 *************
 Build options
 *************

--- a/build_a_container.rst
+++ b/build_a_container.rst
@@ -436,10 +436,12 @@ that is piped through ``stdin``. The following example demonstrates both:
 build an OCI image from a Dockerfile. It checks if there is a ``buildkitd``
 daemon that is already running on the system (and whose permissions allow access
 by the current user), and if so, that daemon is used for the build process. If a
-usable ``buildkitd`` daemon is not found, {Singularity} will launch an
-emphemeral ``buildkitd`` daemon of its own, inside a :ref:`user namespace
-<setuid_and_userns>`, that will be used for the build process and torn down when
-the build is complete.
+usable ``buildkitd`` daemon is not found, {Singularity} will launch an ephemeral
+build daemon of its own, inside a :ref:`user namespace <setuid_and_userns>`,
+that will be used for the build process and torn down when the build is
+complete. This ephemeral build daemon is based on `moby/buildkit
+<httpshttps://github.com/moby/buildkit/>`__, but is embedded within
+{Singularity} and runs as part of the same process.
 
 .. note::
 

--- a/definition_files.rst
+++ b/definition_files.rst
@@ -106,9 +106,9 @@ Other bootstrap agents
    Scientific Linux)
 -  :ref:`debootstrap <build-debootstrap>` (apt-based systems such as
    Debian and Ubuntu)
--  :ref:`oci <cli-oci-bootstrap-agent>` (bundle compliant with OCI Image
+-  :ref:`oci <docker-daemon>` (bundle compliant with OCI Image
    Specification)
--  :ref:`oci-archive <cli-oci-archive-bootstrap-agent>` (tar files
+-  :ref:`oci-archive <docker-archive>` (tar files
    obeying the OCI Image Layout Specification)
 -  :ref:`docker-daemon <docker-daemon>` (images managed by the
    locally running docker daemon)

--- a/oci_runtime.rst
+++ b/oci_runtime.rst
@@ -69,6 +69,8 @@ Users are encouraged to employ OCI-mode when their primary use-case for
 registries. Behavior will more closely match that described for Docker than with
 {Singularity}'s native runtime.
 
+.. _oci_sysreq:
+
 System Requirements
 ===================
 
@@ -167,7 +169,7 @@ registry in question, anonymous authentication will be used instead.
 
 However, the ``run / shell / exec`` and ``pull`` commands can also use
 credentials stored in a different file of the user's choosing, by specifying the
-``--authfile <path>`` flag. See the :ref:`documentation of the --authfile flag
+``--authfile <path>`` flag. See the :ref:`documentation of the authfile flag
 <sec:authfile>` for details on how to create and use custom credential files.
 
 .. _oci_compat:

--- a/registry.rst
+++ b/registry.rst
@@ -10,9 +10,8 @@ images. Some registries require credentials to access certain images or even the
 registry itself. Previously, the only method in {Singularity} to supply
 credentials to registries was to supply credentials for each command or set
 environment variables to contain the credentials for a single registry. See
-:ref:`Authentication via Interactive Login
-<sec:authentication_via_docker_login>` and :ref:`Authentication via Environment
-Variables <sec:authentication_via_environment_variables>`.
+:ref:`Authentication via Interactive Login <sec:docker_login>` and
+:ref:`Authentication via Environment Variables <sec:docker_envvars>`.
 
 Starting with {Singularity} 4.0, users can supply credentials
 on a per-registry basis with the ``registry`` command.

--- a/security.rst
+++ b/security.rst
@@ -57,6 +57,8 @@ and processes apply. In a default installation, {Singularity} uses a
 setuid starter binary to perform only the specific tasks needed to setup
 the container.
 
+.. _setuid_and_userns:
+
 ************************
 Setuid & User Namespaces
 ************************

--- a/singularity_and_docker.rst
+++ b/singularity_and_docker.rst
@@ -160,6 +160,8 @@ SIF, and then always run from the SIF file, rather than using
 Alternatively, if you have signed up for a Docker Hub account, make sure
 that you authenticate before using ``docker://`` container URIs.
 
+.. _docker_auth:
+
 Authentication / Private Containers
 ===================================
 
@@ -214,6 +216,8 @@ login.
    {Singularity} can only read credentials stored directly in
    ``~/.docker/config.json``. It cannot read credentials from external
    Docker credential helpers.
+
+.. _sec:docker_login:
 
 Interactive Login
 -----------------
@@ -640,7 +644,7 @@ ways:
    ``--authfile <path>`` flag to the ``build`` command. Note, however, that this
    will store the relevant credentials unencrypted in the specified file, so
    appropriate care must be taken concerning the location, ownership, and
-   permissions of this file. See the :ref:`documentation of the --authfile flag
+   permissions of this file. See the :ref:`documentation of the authfile flag
    <sec:authfile>` for more information.
 
 If you are running the build under your account via the ``--fakeroot``

--- a/singularity_and_docker.rst
+++ b/singularity_and_docker.rst
@@ -501,6 +501,8 @@ Ubuntu image for a 64-bit ARM system:
 
    $ singularity pull --arch arm64 docker://ubuntu
 
+.. _qemu:
+
 CPU emulation
 =============
 


### PR DESCRIPTION
## Description of the Pull Request (PR):

Documents support for building OCI-SIF from Dockerfiles using `build --oci`, added in https://github.com/sylabs/singularity/pull/2280

