### PR TITLE
update Go, node, and python versions (4.0)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,15 +7,15 @@ orbs:
 parameters:
   go-version:
     type: string
-    default: '1.21.1'
+    default: '1.21.4'
 
 executors:
   node:
     docker:
-      - image: node:18-slim
+      - image: node:20-slim
   python:
     docker:
-      - image: python:3.9-bullseye
+      - image: python:3.12-bullseye
   ubuntu-machine:
     machine:
      image: ubuntu-2204:2023.07.2


### PR DESCRIPTION
## Description of the Pull Request (PR):

Pick #223 

Update CircleCI versions of: Go (1.21.4), node (20-slim), and python (3.12).

