### PR TITLE
Add instructions on how to build from a local Docker image

### DIFF
--- a/build_a_container.rst
+++ b/build_a_container.rst
@@ -73,6 +73,17 @@ them into {Singularity} containers.
 
    $ sudo singularity build lolcow.sif docker://sylabsio/lolcow
 
+*************************************************
+Building from an existing local Docker container
+*************************************************
+
+You can also use ``build`` to create a {Singularity} container
+from a local Docker image.
+
+.. code::
+
+   $ sudo singularity build lolcow.sif docker-daemon://lolcow:latest
+
 .. _create_a_writable_container:
 
 *******************************************


### PR DESCRIPTION
I have often needed to build a Apptainer container from a local Docker image (not from a remote image in a Docker registry). I think that this might be a relatively popular use-case, but currently this workaround is only described in an issue on GitHub (https://github.com/apptainer/singularity/issues/1537#issuecomment-557527638).

It would be nice to also have it in the official docs.