### PR TITLE
Fixed a typo in the documentation

### DIFF
--- a/build_a_container.rst
+++ b/build_a_container.rst
@@ -219,7 +219,7 @@ flag:
 
    $ singularity build --fakeroot lolcow.sif lolcow.def
 
-Unprivilged ``proot`` builds
+Unprivileged ``proot`` builds
 ============================
 
 {Singularity} 3.11 introduces the ability to run some definition file builds


### PR DESCRIPTION
## Description of the Pull Request (PR):

This is a very simple typo fix. The heading for "Unprivilged proot builds" was edited to "Unprivileged proot builds"
