### PR TITLE
Drop EL7 (EOL) content

### DIFF
--- a/bind_paths_and_mounts.rst
+++ b/bind_paths_and_mounts.rst
@@ -340,13 +340,11 @@ correctly with {Singularity}. Older versions do not support the way in
 which the {Singularity} runtime passes a pre-mounted file descriptor
 into the container.
 
-If you are using an older distribution that provides FUSE commands such
-as ``sshfs`` based on FUSE 2 then you can install FUSE 3 versions of the
-commands you need inside your container. EL7 distributions can install a
-compatible version of FUSE 3 from the EPEL repository. EL8 distributions
-ship FUSE 3.2.1 as a base package. Unfortunately this is an older version
-which does not fully support the way in which {Singularity} prepares FUSE
-mounts.
+If you are using an older distribution that provides FUSE commands such as
+``sshfs`` based on FUSE 2 then you can install FUSE 3 versions of the commands
+you need inside your container. EL8 distributions ship FUSE 3.2.1 as a base
+package. Unfortunately this is an older version which does not fully support the
+way in which {Singularity} prepares FUSE mounts.
 
 FUSE mount definitions
 ======================

--- a/introduction.rst
+++ b/introduction.rst
@@ -53,7 +53,7 @@ most people are most familiar with. It is where applications, libraries
 and system services run.
 
 Traditionally you use an operating system that has a fixed combination
-of kernel and user space. If you have access to a machine running CentOS
+of kernel and user space. If you have access to a machine running RHEL
 then you cannot install software that was packaged for Ubuntu on it,
 because the user space of these distributions is not compatible. It can
 also be very difficult to install multiple versions of the same
@@ -63,7 +63,7 @@ workflows over time.
 Containers change the user space into a swappable component. This means
 that the entire user space portion of a Linux operating system,
 including programs, custom configurations, and environment can be
-independent of whether your system is running CentOS, Fedora etc.,
+independent of whether your system is running RHEL, Fedora etc.,
 underneath. A {Singularity} container packages up whatever you need into
 a single, verifiable file.
 

--- a/quick_start.rst
+++ b/quick_start.rst
@@ -76,9 +76,9 @@ On versions 8 or later of RHEL / Alma Linux / Rocky Linux, as well as on Fedora:
 .. code::
 
    # Install basic tools for compiling
-   sudo yum groupinstall -y 'Development Tools'
+   sudo dnf groupinstall -y 'Development Tools'
    # Install RPM packages for dependencies
-   sudo yum install -y \
+   sudo dnf install -y \
       autoconf \
       automake \
       crun \
@@ -88,27 +88,6 @@ On versions 8 or later of RHEL / Alma Linux / Rocky Linux, as well as on Fedora:
       glib2-devel \
       libseccomp-devel \
       libtool \
-      squashfs-tools \
-      wget \
-      zlib-devel
-
-On version 7 of RHEL / CentOS:
-
-.. code::
-
-   # Install basic tools for compiling
-   sudo yum groupinstall -y 'Development Tools'
-   # Install RPM packages for dependencies
-   sudo yum install -y \
-      autoconf \
-      automake \
-      cryptsetup \
-      fuse3-devel \
-      git \
-      glib2-devel \
-      libseccomp-devel \
-      libtool \
-      runc \
       squashfs-tools \
       wget \
       zlib-devel
@@ -165,32 +144,20 @@ On Fedora, the ``squashfs-tools`` package, included in the :ref:`Install system
 dependencies <sec:sysdeps>` step above, includes `sqfstar`. No further action is
 necessary.
 
-RHEL / Alma Linux / Rocky Linux / CentOS
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+RHEL / Alma Linux / Rocky Linux
+"""""""""""""""""""""""""""""""
 
-On RHEL and derivatives, a COPR is available at:
-https://copr.fedorainfracloud.org/coprs/dctrud/squashfs-tools-ng/
+On RHEL and derivatives, the ``squashfs-tools-ng`` package is now available in
+the EPEL repositories.
 
-This COPR provides ``squashfs-tools-ng``, which will not replace any standard EL or
-EPEL packages. To use it:
-
-EL 8 / 9
-""""""""
+Follow the `EPEL Quickstart <https://docs.fedoraproject.org/en-US/epel/#_quickstart>`__
+for you distribution to enable the EPEL repository. Install ``squashfs-tools-ng`` with
+``dnf``.
 
 .. code::
 
-  sudo dnf install dnf-plugins-core
-  sudo dnf copr enable dctrud/squashfs-tools-ng 
-  sudo dnf install squashfs-tools-ng
+   sudo dnf install squashfs-tools-ng
 
-EL 7
-""""
-
-.. code::
-
-  sudo yum install yum-plugin-copr 
-  sudo yum copr enable dctrud/squashfs-tools-ng 
-  sudo yum install squashfs-tools-ng
 
 SLES / openSUSE Leap
 ^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
EL7 is end of life. Remove references to installation on it, and compatibility issues.