### PR TITLE
Document --layer-format tar

### DIFF
--- a/new.rst
+++ b/new.rst
@@ -12,6 +12,15 @@ If you are upgrading from a 3.x version of {Singularity} we recommend also
 reviewing the `"What's New" section for 4.0
 <https://docs.sylabs.io/guides/4.0/user-guide/new.html>`__.
 
+********
+OCI-mode
+********
+
+- A new ``--layer-format tar`` flag for ``singularity push`` allows layers in an
+  OCI-SIF image to be pushed to ``library://`` and ``docker://`` registries with
+  layers in the standard OCI tar format. Images pushed with ``--layer-format``
+  tar can be pulled and run by other OCI runtimes. See :ref:`sec:layer-format`
+
 *******
 Runtime
 *******
@@ -22,3 +31,4 @@ Runtime
   allowed ``netns paths directive`` in ``singularity.conf``, if they are also
   listed in ``allow net users`` / ``allow net groups``. Not currently supported
   with ``--fakeroot``, or in ``--oci`` mode. See :ref:`sec:netns-path`.
+

--- a/singularity_and_docker.rst
+++ b/singularity_and_docker.rst
@@ -1476,3 +1476,35 @@ Section          Description                 Section          Description
                  | container.                                 | key-value pair.
 
 ================ =========================== ================ =============================
+
+********************************************
+Running {Singularity} Containers With Docker
+********************************************
+
+Beginning with {Singularity} 4.2, it is possible to push OCI-SIF containers,
+created in OCI-Mode, to a registry in a manner that is compatible with other OCI
+runtimes.
+
+To push an image from an OCI-SIF to an OCI registry for consumption with another
+runtime, use the ``--layer-format tar`` flag. This pushes the image layers to
+the registry in OCI tar format, rather than {Singularity}'s default SquashFS
+format.
+
+.. code::
+
+   # Push to Docker Hub in OCI tar format
+   $ singularity push --layer-format=tar \
+      python_latest.oci.sif \
+      docker://docker.io/dctrud/oci-example:latest
+
+   # Run with Docker
+   $ docker run -it --rm dctrud/oci-example:latest
+   Unable to find image 'dctrud/oci-example:latest' locally
+   latest: Pulling from dctrud/oci-example
+   Digest: sha256:679194c0d918a5d1992176011332253fc75737e8fbc52677f9839ec031e166ea
+   Status: Downloaded newer image for dctrud/oci-example:latest
+   Python 3.12.5 (main, Aug 13 2024, 02:19:05) [GCC 12.2.0] on linux
+   Type "help", "copyright", "credits" or "license" for more information.
+   >>> 
+
+For more information, see :ref:`sec:layer-format`.


### PR DESCRIPTION
Document pushing OCI-SIF images to an OCI registry with `--layer-format tar` for consumption by other runtimes.

Fixes #243