### PR TITLE
Bump singularity_source, CI, and update quick_start deps

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ orbs:
 parameters:
   go-version:
     type: string
-    default: '1.21.6'
+    default: '1.22.6'
 
 executors:
   node:
@@ -18,7 +18,7 @@ executors:
       - image: python:3.12-bullseye
   ubuntu-machine:
     machine:
-     image: ubuntu-2204:2023.10.1
+     image: ubuntu-2404:2024.05.1
 
 commands:
   install-deps-apt:
@@ -63,8 +63,11 @@ commands:
         default: true
     steps:
       - run:
+          name: Create venv
+          command: <<# parameters.sudo >>sudo <</ parameters.sudo >>python3 -m venv sphinx-venv
+      - run:
           name: Install python dependencies
-          command: <<# parameters.sudo >>sudo <</ parameters.sudo >>pip install 'sphinx<6' sphinx-rtd-theme rstcheck pygments m2r2
+          command: <<# parameters.sudo >>sudo <</ parameters.sudo >>sphinx-venv/bin/pip install 'sphinx<6' sphinx-rtd-theme rstcheck pygments m2r2
   init-submodules:
     steps:
       - run:
@@ -92,6 +95,7 @@ jobs:
       - run:
           name: Lint rst
           command: |
+            source sphinx-venv/bin/activate
             rstcheck --ignore-languages c,c++ --report-level warning *.rst
 
   make_docs:
@@ -107,6 +111,7 @@ jobs:
       - run:
           name: make html
           command: |
+            source sphinx-venv/bin/activate
             make html
       - store_artifacts:
           path: _build/html
@@ -114,6 +119,7 @@ jobs:
       - run:
           name: make pdf
           command: |
+            source sphinx-venv/bin/activate
             make latexpdf
       - store_artifacts:
           path: _build/latex
@@ -121,6 +127,7 @@ jobs:
       - run:
           name: make epub
           command: |
+            source sphinx-venv/bin/activate
             make epub
       - store_artifacts:
           path: _build/epub
@@ -139,14 +146,17 @@ jobs:
       - run:
           name: make pdf
           command: |
+            source sphinx-venv/bin/activate
             make latexpdf
       - run:
           name: make html
           command: |
+            source sphinx-venv/bin/activate
             make html
       - run:
           name: make epub
           command: |
+            source sphinx-venv/bin/activate
             make epub
       - aws-cli/setup
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,6 +44,7 @@ commands:
               libseccomp-dev \
               libtool \
               pkg-config \
+              python3-venv \
               squashfs-tools \
               uidmap \
               zlib1g-dev
@@ -57,17 +58,16 @@ commands:
           name: Install LaTeX environment
           command: <<# parameters.sudo >>sudo <</ parameters.sudo >>DEBIAN_FRONTEND=noninteractive apt-get -q install -y texlive-latex-extra latexmk
   install-deps-python:
-    parameters:
-      sudo:
-        type: boolean
-        default: true
     steps:
       - run:
           name: Create venv
-          command: <<# parameters.sudo >>sudo <</ parameters.sudo >>python3 -m venv sphinx-venv
+          command: python3 -m venv sphinx-venv
       - run:
           name: Install python dependencies
-          command: <<# parameters.sudo >>sudo <</ parameters.sudo >>sphinx-venv/bin/pip install 'sphinx<6' sphinx-rtd-theme rstcheck pygments m2r2
+          command: |
+            source sphinx-venv/bin/activate
+            pip install setuptools 'sphinx<6' sphinx-rtd-theme rstcheck pygments m2r2
+
   init-submodules:
     steps:
       - run:
@@ -90,8 +90,7 @@ jobs:
     executor: python
     steps:
       - checkout
-      - install-deps-python:
-         sudo: false
+      - install-deps-python
       - run:
           name: Lint rst
           command: |

--- a/quick_start.rst
+++ b/quick_start.rst
@@ -58,7 +58,9 @@ On Debian-based systems, including Ubuntu:
       autoconf \
       automake \
       cryptsetup \
+      fuse2fs \
       git \
+      fuse \
       libfuse-dev \
       libglib2.0-dev \
       libseccomp-dev \
@@ -83,6 +85,8 @@ On versions 8 or later of RHEL / Alma Linux / Rocky Linux, as well as on Fedora:
       automake \
       crun \
       cryptsetup \
+      fuse \
+      fuse3 \
       fuse3-devel \
       git \
       glib2-devel \
@@ -101,6 +105,8 @@ On SLES / openSUSE Leap:
     autoconf \
     automake \
     cryptsetup \
+    fuse2fs \
+    fuse3 \
     fuse3-devel \
     gcc \
     gcc-c++ \
@@ -207,7 +213,7 @@ replace specific values as needed:
 
 .. code::
 
-   $ export VERSION=1.21.0 OS=linux ARCH=amd64 && \
+   $ export VERSION={GoVersion} OS=linux ARCH=amd64 && \
      wget https://dl.google.com/go/go$VERSION.$OS-$ARCH.tar.gz && \
      sudo tar -C /usr/local -xzvf go$VERSION.$OS-$ARCH.tar.gz && \
      rm go$VERSION.$OS-$ARCH.tar.gz

--- a/replacements.py
+++ b/replacements.py
@@ -20,6 +20,7 @@ variable_replacements = {
     # replace to SingularityPRO so that it is clearer where docs
     # diverge a bit from CE<->PRO due to long-term backports etc.
     "{Singularity}": "SingularityCE",
+    "{GoVersion}": "1.22.6",
 }
 
 


### PR DESCRIPTION
* Bump singularity_source submodule to current release-4.2 branch HEAD.
* Update CI machine and Go version.
* Update the quick_start install documentation.