### PR TITLE
fix code block formatting in quick start guide

### DIFF
--- a/quick_start.rst
+++ b/quick_start.rst
@@ -74,40 +74,40 @@ On Debian-based systems, including Ubuntu:
 
 On Ubuntu 24.04 and above install additional libsubid headers:
 
-```sh
-sudo apt-get install -y libsubid-dev
-```
+.. code::
+
+   sudo apt-get install -y libsubid-dev
 
 On RHEL / Alma Linux / Rocky Linux, CentOS Stream, you will need to enable the
 CRB (9+) or powertools repository (8). This is not necessary on Fedora.
 
-```sh
-sudo dnf install -y dnf-plugins-core
-sudo dnf config-manager --enable crb || dnf config-manager --enable powertools
-```
+.. code::
+
+   sudo dnf install -y dnf-plugins-core
+   sudo dnf config-manager --enable crb || dnf config-manager --enable powertools
 
 You can now install the build dependencies:
 
-```sh
-# Install basic tools for compiling
-sudo dnf groupinstall -y 'Development Tools'
-# Install RPM packages for dependencies
-sudo dnf --enablerepo=devel install -y \
-    autoconf \
-    automake \
-    crun \
-    cryptsetup \
-    fuse \
-    fuse3 \
-    fuse3-devel \
-    git \
-    libseccomp-devel \
-    libtool \
-    shadow-utils-subid-devel \
-    squashfs-tools \
-    wget \
-    zlib-devel
-```
+.. code::
+
+   # Install basic tools for compiling
+   sudo dnf groupinstall -y 'Development Tools'
+   # Install RPM packages for dependencies
+   sudo dnf --enablerepo=devel install -y \
+      autoconf \
+      automake \
+      crun \
+      cryptsetup \
+      fuse \
+      fuse3 \
+      fuse3-devel \
+      git \
+      libseccomp-devel \
+      libtool \
+      shadow-utils-subid-devel \
+      squashfs-tools \
+      wget \
+      zlib-devel
 
 Install sqfstar / tar2sqfs for OCI-mode
 ---------------------------------------


### PR DESCRIPTION
## Description of the Pull Request (PR):

Currently, some of the code blocks in the quick start page https://docs.sylabs.io/guides/latest/user-guide/quick_start.html is broken.

<img width="743" alt="Screenshot 2025-04-30 at 16 23 31" src="https://github.com/user-attachments/assets/f418f98e-f9ec-4e8c-8d22-a2f8315986f9" />

## After applying this patch:

<img width="763" alt="Screenshot 2025-04-30 at 16 24 19" src="https://github.com/user-attachments/assets/f40bbd8c-7b6a-4489-b89d-ae6a1e4fecd0" />

